### PR TITLE
Owner permissions (task #2329)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+use Cake\Event\EventManager;
+use RolesCapabilities\Event\ModelBeforeFindEventsListener;
+
+EventManager::instance()->on(new ModelBeforeFindEventsListener());

--- a/src/Capability.php
+++ b/src/Capability.php
@@ -34,6 +34,12 @@ class Capability
     protected $_description;
 
     /**
+     * Capability field
+     * @var string
+     */
+    protected $_field;
+
+    /**
      * Constructor method
      * @param string $name    Capability name
      * @param array  $options Capability options
@@ -48,6 +54,10 @@ class Capability
         $this->setLabel($options['label']);
 
         $this->setDescription($options['description']);
+
+        if (isset($options['field'])) {
+            $this->setField($options['field']);
+        }
     }
 
     /**
@@ -123,5 +133,28 @@ class Capability
     public function getDescription()
     {
         return $this->_description;
+    }
+
+    /**
+     * Set field
+     *
+     * @param string $field Capability field
+     * @return Capability
+     */
+    public function setField($field)
+    {
+        $this->_field = $field;
+
+        return $this;
+    }
+
+    /**
+     * Get field
+     *
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->_field;
     }
 }

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -36,7 +36,7 @@ trait CapabilityTrait
      * @param  array  $actions        Controller actions
      * @return array
      */
-    public static function getCapabilities($controllerName, array $actions = [])
+    public static function getCapabilities($controllerName = null, array $actions = [])
     {
         return static::_getCapabilitiesTable()->getCapabilities($controllerName, $actions);
     }

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -33,11 +33,12 @@ trait CapabilityTrait
      * Returns permission capabilities.
      *
      * @param  string $controllerName Controller Name
+     * @param  array  $actions        Controller actions
      * @return array
      */
-    public static function getCapabilities($controllerName = null)
+    public static function getCapabilities($controllerName, array $actions = [])
     {
-        return static::_getCapabilitiesTable()->getCapabilities($controllerName);
+        return static::_getCapabilitiesTable()->getCapabilities($controllerName, $actions);
     }
 
     /**

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -51,45 +51,10 @@ trait CapabilityTrait
      */
     protected function _checkAccess(Event $event)
     {
-        $requestParams = $event->subject()->request->params;
-        $plugin = is_null($requestParams['plugin']) ? 'App' : $requestParams['plugin'];
-        $controllerName = App::className($plugin . '.' . $event->subject()->name . 'Controller', 'Controller');
-        $capability = static::_generateCapabilityName(
-            static::_generateCapabilityControllerName($controllerName),
-            $requestParams['action']
+        static::_getCapabilitiesTable()->checkAccess(
+            $event->subject()->request->params,
+            $this->Auth->user()
         );
-        $allCapabilities = $this->getCapabilities($controllerName);
-        $capExists = false;
-        foreach ($allCapabilities as $cap) {
-            if ($cap->getName() === $capability) {
-                $capExists = true;
-                break;
-            }
-        }
-
-        $hasAccess = false;
-        if ($capExists) {
-            if ($this->Capability->hasAccess($capability)) {
-                $hasAccess = true;
-            } else {
-                $hasAccess = false;
-            }
-        } else {
-            /*
-            if capability does not exist user is allowed access
-             */
-            $hasAccess = true;
-        }
-
-        /*
-        superuser has access everywhere
-         */
-        if ($this->Auth->user('is_superuser')) {
-            $hasAccess = true;
-        }
-        if (!$hasAccess) {
-            throw new ForbiddenException();
-        }
     }
 
     /**

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -50,27 +50,29 @@ class CapabilityComponent extends Component
         $this->_controller = $this->_registry->getController();
         $this->_user = $this->Auth->user();
         $this->_capabilitiesTable = TableRegistry::get('RolesCapabilities.Capabilities');
+        $this->_capabilitiesTable->setCurrentUser($this->Auth->user());
     }
 
     /**
      * Method that retrieves all defined capabilities
+     *
      * @return array capabilities
      */
     public function getAllCapabilities()
     {
-        $capabilities = [];
-        // get all controllers
-        $controllers = $this->_getAllControllers();
+        $result = [];
 
-        foreach ($controllers as $controller) {
+        foreach ($this->_getAllControllers() as $controller) {
             if (is_callable([$controller, 'getCapabilities'])) {
-                foreach ($controller::getCapabilities($controller) as $capability) {
-                    $capabilities[$controller][$capability->getName()] = $capability->getDescription();
+                foreach ($controller::getCapabilities($controller) as $type => $capabilities) {
+                    foreach ($capabilities as $capability) {
+                        $result[$controller][$capability->getName()] = $capability->getDescription();
+                    }
                 }
             }
         }
 
-        return $capabilities;
+        return $result;
     }
 
     /**

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -50,6 +50,7 @@ class CapabilityComponent extends Component
         $this->_controller = $this->_registry->getController();
         $this->_user = $this->Auth->user();
         $this->_capabilitiesTable = TableRegistry::get('RolesCapabilities.Capabilities');
+        $this->_capabilitiesTable->setCurrentRequest($config['currentRequest']);
         $this->_capabilitiesTable->setCurrentUser($this->Auth->user());
     }
 

--- a/src/Controller/RolesController.php
+++ b/src/Controller/RolesController.php
@@ -56,6 +56,7 @@ class RolesController extends AppController
             }
             if ($this->Roles->save($role)) {
                 $this->Flash->success(__('The role has been saved.'));
+
                 return $this->redirect(['action' => 'index']);
             } else {
                 $this->Flash->error(__('The role could not be saved. Please, try again.'));
@@ -92,6 +93,7 @@ class RolesController extends AppController
 
             if ($this->Roles->save($role)) {
                 $this->Flash->success(__('The role has been saved.'));
+
                 return $this->redirect(['action' => 'index']);
             } else {
                 $this->Flash->error(__('The role could not be saved. Please, try again.'));
@@ -121,6 +123,7 @@ class RolesController extends AppController
         } else {
             $this->Flash->error(__('The role could not be deleted. Please, try again.'));
         }
+
         return $this->redirect(['action' => 'index']);
     }
 }

--- a/src/Event/ModelBeforeFindEventsListener.php
+++ b/src/Event/ModelBeforeFindEventsListener.php
@@ -1,0 +1,70 @@
+<?php
+namespace RolesCapabilities\Event;
+
+use ArrayObject;
+use Cake\Core\App;
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+
+class ModelBeforeFindEventsListener implements EventListenerInterface
+{
+
+    /**
+     * Implemented Events
+     *
+     * @return array
+     */
+    public function implementedEvents()
+    {
+        return [
+            'Model.beforeFind' => 'checkRecordAccess',
+        ];
+    }
+
+    /**
+     * Check
+     *
+     * @param  \Cake\Event\Event $event Event object
+     * @param  Cake\Datasource\EntityInterface $entity Translation entity
+     * @param  ArrayObject $options entity options
+     * @return void
+     */
+    public function checkRecordAccess(Event $event, Query $query, ArrayObject $options)
+    {
+        $table = TableRegistry::get('RolesCapabilities.Capabilities');
+
+        // current request parameters
+        $request = $table->getCurrentRequest();
+
+        // skip if current model does not match request's model
+        if (array_diff(
+            pluginSplit($event->subject()->registryAlias()),
+            [$request['plugin'], $request['controller']]
+        )) {
+            return;
+        }
+
+        // get capability owner type identifier
+        $type = $table->getTypeOwner();
+
+        // get user's action capabilities
+        $userActionCapabilities = $table->getUserActionCapabilities();
+
+        // skip if no user's action capabilities found or no user's action
+        // owner specific capabilities found for current request's action
+        if (empty($userActionCapabilities)) {
+            return;
+        }
+
+        if (!isset($userActionCapabilities[$request['plugin']][$request['controller']][$request['action']][$type])) {
+            return;
+        }
+
+        // set query where clause based on user's owner capabilities assignment fields
+        foreach ($userActionCapabilities[$request['plugin']][$request['controller']][$request['action']][$type] as $userActionCapability) {
+            $query->where([$userActionCapability->getField() => $table->getCurrentUser('id')]);
+        }
+    }
+}

--- a/src/Event/ModelBeforeFindEventsListener.php
+++ b/src/Event/ModelBeforeFindEventsListener.php
@@ -26,9 +26,9 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
     /**
      * Check
      *
-     * @param  \Cake\Event\Event $event Event object
-     * @param  Cake\Datasource\EntityInterface $entity Translation entity
-     * @param  ArrayObject $options entity options
+     * @param \Cake\Event\Event $event The beforeFind event that was fired.
+     * @param \Cake\ORM\Query $query Query
+     * @param \ArrayObject $options The options for the query
      * @return void
      */
     public function checkRecordAccess(Event $event, Query $query, ArrayObject $options)

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -75,6 +75,15 @@ class CapabilitiesTable extends Table
     ];
 
     /**
+     * Non-assignation actions
+     *
+     * @var array
+     */
+    protected $_nonAssignationActions = [
+        'add'
+    ];
+
+    /**
      * Initialize method
      *
      * @param array $config The configuration for the Table.

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -277,8 +277,6 @@ class CapabilitiesTable extends Table
             if (!$hasAccess) {
                 $hasAccess = $this->_hasTypeAccess($this->getTypeOwner(), $actionCapabilities, $user, $subject);
             }
-        } else { // if capability does not exist for current action, user is allowed access
-            $hasAccess = true;
         }
 
         if (!$hasAccess) {

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -51,6 +51,13 @@ class CapabilitiesTable extends Table
     ];
 
     /**
+     * Current user details
+     *
+     * @var array
+     */
+    protected $_currentUser = [];
+
+    /**
      * Initialize method
      *
      * @param array $config The configuration for the Table.
@@ -121,6 +128,31 @@ class CapabilitiesTable extends Table
     public function getTypeOwner()
     {
         return static::CAP_TYPE_OWNER;
+    }
+
+    /**
+     * Current user info setter.
+     *
+     * @param array $user
+     */
+    public function setCurrentUser(array $user = [])
+    {
+        $this->_currentUser = $user;
+    }
+
+    /**
+     * Current user info getter.
+     *
+     * @param  string|null       $key Specific field to retrieve
+     * @return array|string|null
+     */
+    public function getCurrentUser($key = null)
+    {
+        if (!is_null($key)) {
+            return isset($this->_currentUser[$key]) ? $this->_currentUser[$key] : null;
+        }
+
+        return $this->_currentUser;
     }
 
     /**

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -324,6 +324,28 @@ class CapabilitiesTable extends Table
     }
 
     /**
+     * Method that retrieves and returns Table's assignation fields. These are fields
+     * that dictate assigment, usually foreign key associated with a Users tables. (example: assigned_to)
+     *
+     * @param  \Cake\ORM\Table $table Table instance
+     * @return array
+     */
+    protected function _getTableAssignationFields(Table $table)
+    {
+        $fields = [];
+        foreach ($table->associations() as $association) {
+            // skip non-assignation models
+            if (!in_array($association->className(), $this->_assignationModels)) {
+                continue;
+            }
+
+            $fields[] = $association->foreignKey();
+        }
+
+        return $fields;
+    }
+
+    /**
      * Method that checks if current user is allowed access.
      * Returns true if current user has access, false otherwise.
      * @param  string $capability capability name

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -82,11 +82,11 @@ class CapabilitiesTable extends Table
     ];
 
     /**
-     * Non-assignation actions
+     * Non-assigned actions
      *
      * @var array
      */
-    protected $_nonAssignationActions = [
+    protected $_nonAssignedActions = [
         'add'
     ];
 
@@ -444,13 +444,13 @@ class CapabilitiesTable extends Table
                     )
                 ]
             );
-            // skip rest of the logic if assignation fields are not found
+            // skip rest of the logic if assignment fields are not found
             // or if current action does not support assignment (Example: add / create)
-            if (empty($assignationFields) || in_array($action, $this->_nonAssignationActions)) {
+            if (empty($assignationFields) || in_array($action, $this->_nonAssignedActions)) {
                 continue;
             }
 
-            // generate action's owner (assignation field) type capabilities
+            // generate action's owner (assignment field) type capabilities
             foreach ($assignationFields as $assignationField) {
                 $result[static::CAP_TYPE_OWNER][] = new Cap(
                     $this->generateCapabilityName($controllerName, $action . '_' . $assignationField),

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -271,11 +271,11 @@ class CapabilitiesTable extends Table
 
         // current action has capabilities
         if (!empty($actionCapabilities)) {
-            $hasAccess = $this->_checkTypeAccess($this->getTypeFull(), $actionCapabilities, $user, $subject);
+            $hasAccess = $this->_hasTypeAccess($this->getTypeFull(), $actionCapabilities, $user, $subject);
 
             // if user has no full access capabilities
             if (!$hasAccess) {
-                $hasAccess = $this->_checkTypeAccess($this->getTypeOwner(), $actionCapabilities, $user, $subject);
+                $hasAccess = $this->_hasTypeAccess($this->getTypeOwner(), $actionCapabilities, $user, $subject);
             }
         } else { // if capability does not exist for current action, user is allowed access
             $hasAccess = true;
@@ -295,7 +295,7 @@ class CapabilitiesTable extends Table
      * @param  array  $user               User info
      * @return bool
      */
-    protected function _checkTypeAccess($type, array $actionCapabilities, array $user, array $url)
+    protected function _hasTypeAccess($type, array $actionCapabilities, array $user, array $url)
     {
         // skip if action has no access capabilities for specified type
         if (!isset($actionCapabilities[$type])) {

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -22,6 +22,16 @@ use RolesCapabilities\Model\Entity\Capability;
 class CapabilitiesTable extends Table
 {
     /**
+     * Full type capability identifier
+     */
+    const CAP_TYPE_FULL = 'full';
+
+    /**
+     * Owner type capability identifier
+     */
+    const CAP_TYPE_OWNER = 'owner';
+
+    /**
      * Default skip controllers
      *
      * @var array
@@ -33,6 +43,7 @@ class CapabilitiesTable extends Table
 
     /**
      * Default skip actions
+     *
      * @var array
      */
     protected $_skipActions = [
@@ -90,6 +101,26 @@ class CapabilitiesTable extends Table
     {
         $rules->add($rules->existsIn(['role_id'], 'Roles'));
         return $rules;
+    }
+
+    /**
+     * Get full type capability identifier.
+     *
+     * @return string
+     */
+    public function getTypeFull()
+    {
+        return static::CAP_TYPE_FULL;
+    }
+
+    /**
+     * Get owner type capability identifier.
+     *
+     * @return string
+     */
+    public function getTypeOwner()
+    {
+        return static::CAP_TYPE_OWNER;
     }
 
     /**

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -140,6 +140,7 @@ class CapabilitiesTable extends Table
     public function buildRules(RulesChecker $rules)
     {
         $rules->add($rules->existsIn(['role_id'], 'Roles'));
+
         return $rules;
     }
 
@@ -166,7 +167,8 @@ class CapabilitiesTable extends Table
     /**
      * Current request parameters setter.
      *
-     * @param array $request
+     * @param  array $request Request parameters
+     * @return void
      */
     public function setCurrentRequest(array $request)
     {
@@ -191,7 +193,8 @@ class CapabilitiesTable extends Table
     /**
      * Current user info setter.
      *
-     * @param array|null $user
+     * @param  array|null $user User information
+     * @return void
      */
     public function setCurrentUser($user)
     {
@@ -216,11 +219,12 @@ class CapabilitiesTable extends Table
     /**
      * User action capability setter.
      *
-     * @param string                        $plugin     Plugin name
-     * @param string                        $controller Controller name
-     * @param string                        $action     Action type
-     * @param string                        $type       Capability type
-     * @param \RolesCapabilities\Capability $capability Capability instance
+     * @param  string                        $plugin     Plugin name
+     * @param  string                        $controller Controller name
+     * @param  string                        $action     Action type
+     * @param  string                        $type       Capability type
+     * @param  \RolesCapabilities\Capability $capability Capability instance
+     * @return void
      */
     public function setUserActionCapability($plugin, $controller, $action, $type, Cap $capability)
     {
@@ -433,7 +437,7 @@ class CapabilitiesTable extends Table
             $result[static::CAP_TYPE_FULL][] = new Cap(
                 $this->generateCapabilityName($controllerName, $action),
                 [
-                    'label' => $this->generateCapabilityLabel($controllerName, $action  . '_all'),
+                    'label' => $this->generateCapabilityLabel($controllerName, $action . '_all'),
                     'description' => $this->generateCapabilityDescription(
                         $controllerName,
                         $action . ' to all'

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -191,9 +191,9 @@ class CapabilitiesTable extends Table
     /**
      * Current user info setter.
      *
-     * @param array $user
+     * @param array|null $user
      */
-    public function setCurrentUser(array $user = [])
+    public function setCurrentUser($user)
     {
         $this->_currentUser = $user;
     }
@@ -237,14 +237,19 @@ class CapabilitiesTable extends Table
     /**
      * Check if current user has access to perform action.
      *
-     * @param  array  $subject Subject
-     * @param  array  $user User
+     * @param  array      $subject Subject
+     * @param  array|null $user User
      * @return void
      * @throws Cake\Network\Exception\ForbiddenException
      * @todo                 this needs re-thinking
      */
-    public function checkAccess(array $subject, array $user)
+    public function checkAccess(array $subject, $user)
     {
+        // not logged in
+        if (is_null($user)) {
+            return;
+        }
+
         // superuser has access everywhere
         if ($user['is_superuser']) {
             return;

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -51,6 +51,13 @@ class CapabilitiesTable extends Table
     ];
 
     /**
+     * Current request parameters
+     *
+     * @var array
+     */
+    protected $_currentRequest;
+
+    /**
      * Current user details
      *
      * @var array
@@ -154,6 +161,31 @@ class CapabilitiesTable extends Table
     public function getTypeOwner()
     {
         return static::CAP_TYPE_OWNER;
+    }
+
+    /**
+     * Current request parameters setter.
+     *
+     * @param array $request
+     */
+    public function setCurrentRequest(array $request)
+    {
+        $this->_currentRequest = $request;
+    }
+
+    /**
+     * Current request parameters getter.
+     *
+     * @param  string|null       $key Specific field to retrieve
+     * @return array|string|null
+     */
+    public function getCurrentRequest($key = null)
+    {
+        if (!is_null($key)) {
+            return isset($this->_currentRequest[$key]) ? $this->_currentRequest[$key] : null;
+        }
+
+        return $this->_currentRequest;
     }
 
     /**

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -277,6 +277,38 @@ class CapabilitiesTable extends Table
         $refClass = new ReflectionClass($controllerName);
 
     /**
+     * Method that filters and returns Controller action(s) that can be used for generating access capabilities.
+     *
+     * @param  string $controllerName Controller name
+     * @param  array  $actions        Action(s) to filter. If not specified all controller's public methods will be used.
+     * @return array
+     */
+    protected function _getActions($controllerName, array $actions = [])
+    {
+        $publicMethods = $this->_getControllerPublicMethods($controllerName);
+        // return if controller has no public methods
+        if (empty($publicMethods)) {
+            return [];
+        }
+
+        // if no actions defined, use controller's public methods
+        if (!empty($actions)) {
+            $actions = array_intersect($actions, $publicMethods);
+        } else { // else use controller's public methods
+            $actions = $publicMethods;
+        }
+
+        if (empty($actions)) {
+            return $actions;
+        }
+
+        // filter out skipped actions
+        $actions = $this->_filterSkippedActions($controllerName, $actions);
+
+        return $actions;
+    }
+
+    /**
      * Method that retrieves and returns Controller public methods.
      *
      * @param  string $controllerName Controller name

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -216,12 +216,15 @@ class CapabilitiesTable extends Table
     /**
      * User action capability setter.
      *
+     * @param string                        $plugin     Plugin name
+     * @param string                        $controller Controller name
+     * @param string                        $action     Action type
      * @param string                        $type       Capability type
      * @param \RolesCapabilities\Capability $capability Capability instance
      */
-    public function setUserActionCapability($type, Cap $capability)
+    public function setUserActionCapability($plugin, $controller, $action, $type, Cap $capability)
     {
-        $this->_userActionCapabilities[$type][] = $capability;
+        $this->_userActionCapabilities[$plugin][$controller][$action][$type][] = $capability;
     }
 
     /**
@@ -269,6 +272,9 @@ class CapabilitiesTable extends Table
                 foreach ($actionCapabilities[$this->getTypeFull()] as $actionCapability) {
                     if ($this->hasAccess($actionCapability->getName(), $user['id'])) {
                         $this->setUserActionCapability(
+                            $subject['plugin'],
+                            $subject['controller'],
+                            $subject['action'],
                             $this->getTypeFull(),
                             $actionCapability
                         );
@@ -283,6 +289,9 @@ class CapabilitiesTable extends Table
                 foreach ($actionCapabilities[$this->getTypeOwner()] as $actionCapability) {
                     if ($this->hasAccess($actionCapability->getName(), $user['id'])) {
                         $this->setUserActionCapability(
+                            $subject['plugin'],
+                            $subject['controller'],
+                            $subject['action'],
                             $this->getTypeOwner(),
                             $actionCapability
                         );

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -254,16 +254,17 @@ class CapabilitiesTable extends Table
     }
 
     /**
-     * Returns permission capabilities.
+     * Returns Controller permission capabilities.
      *
-     * @param  string $controllerName Controller Name
+     * @param  string $controllerName Controller name
+     * @param  array  $actions        Controller actions
      * @return array
      */
-    public function getCapabilities($controllerName = null)
+    public function getCapabilities($controllerName, array $actions = [])
     {
         $result = [];
 
-        if (empty($controllerName)) {
+        if (!is_string($controllerName)) {
             return $result;
         }
 
@@ -272,9 +273,21 @@ class CapabilitiesTable extends Table
             return $result;
         }
 
-        $skipActions = array_merge($controllerName::getSkipActions($controllerName), $this->getCakeControllerActions());
+        $actions = $this->_getActions($controllerName, $actions);
 
-        $refClass = new ReflectionClass($controllerName);
+        if (empty($actions)) {
+            return $result;
+        }
+
+        // get controller table instance
+        $controllerTable = $this->_getControllerTableInstance($controllerName);
+
+        return $this->_getCapabilities(
+            $this->generateCapabilityControllerName($controllerName),
+            $actions,
+            $this->_getTableAssignationFields($controllerTable)
+        );
+    }
 
     /**
      * Method that filters and returns Controller action(s) that can be used for generating access capabilities.

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -58,6 +58,13 @@ class CapabilitiesTable extends Table
     protected $_currentUser = [];
 
     /**
+     * User action specific capabilities
+     *
+     * @var array
+     */
+    protected $_userActionCapabilities = [];
+
+    /**
      * Initialize method
      *
      * @param array $config The configuration for the Table.
@@ -153,6 +160,27 @@ class CapabilitiesTable extends Table
         }
 
         return $this->_currentUser;
+    }
+
+    /**
+     * User action capability setter.
+     *
+     * @param string                        $type       Capability type
+     * @param \RolesCapabilities\Capability $capability Capability instance
+     */
+    public function setUserActionCapability($type, Cap $capability)
+    {
+        $this->_userActionCapabilities[$type][] = $capability;
+    }
+
+    /**
+     * User action capabilities getter.
+     *
+     * @return array
+     */
+    public function getUserActionCapabilities()
+    {
+        return $this->_userActionCapabilities;
     }
 
     /**

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -6,6 +6,7 @@ use Cake\Network\Exception\ForbiddenException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 use ReflectionClass;
 use ReflectionMethod;
@@ -185,6 +186,31 @@ class CapabilitiesTable extends Table
         }
 
         return $result;
+    }
+
+    /**
+     * Method that returns Table instance of specified controller.
+     *
+     * @param  string          $controllerName Controller name
+     * @return \Cake\ORM\Table
+     */
+    protected function _getControllerTableInstance($controllerName)
+    {
+        $parts = explode('\\', $controllerName);
+        // get last part, "/ArticlesController"
+        $tableName = array_pop($parts);
+        // remove "Controller" suffix from "/ArticlesController"
+        $tableName = str_replace('Controller', '', $tableName);
+        // remove "/Controller/" part
+        array_pop($parts);
+        // get plugin part "/MyPlugin/"
+        $plugin = array_pop($parts);
+        // prefix plugin to table name if is not "App"
+        if ('App' !== $plugin) {
+            $tableName = $plugin . '.' . $tableName;
+        }
+
+        return TableRegistry::get($tableName);
     }
 
     /**

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -292,6 +292,24 @@ class CapabilitiesTable extends Table
 
         return $actions;
     }
+
+    /**
+     * Method that filter's out skipped actions from Controller's actions list.
+     *
+     * @param  string $controllerName Controller name
+     * @param  array  $actions        Controller actions
+     * @return array
+     */
+    protected function _filterSkippedActions($controllerName, array $actions)
+    {
+        $skipActions = array_merge(
+            $controllerName::getSkipActions($controllerName),
+            $this->getCakeControllerActions()
+        );
+
+        foreach ($actions as $k => $action) {
+            if (in_array($action, $skipActions)) {
+                unset($actions[$k]);
             }
         }
 

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -276,10 +276,22 @@ class CapabilitiesTable extends Table
 
         $refClass = new ReflectionClass($controllerName);
 
+    /**
+     * Method that retrieves and returns Controller public methods.
+     *
+     * @param  string $controllerName Controller name
+     * @return array
+     */
+    protected function _getControllerPublicMethods($controllerName)
+    {
         $actions = [];
+        $refClass = new ReflectionClass($controllerName);
         foreach ($refClass->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            if (!in_array($method->name, $skipActions)) {
-                $actions[] = $method->name;
+            $actions[] = $method->name;
+        }
+
+        return $actions;
+    }
             }
         }
 

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -328,11 +328,11 @@ class CapabilitiesTable extends Table
      * @param  array  $actions        Controller actions
      * @return array
      */
-    public function getCapabilities($controllerName, array $actions = [])
+    public function getCapabilities($controllerName = null, array $actions = [])
     {
         $result = [];
 
-        if (!is_string($controllerName)) {
+        if (is_null($controllerName) || !is_string($controllerName)) {
             return $result;
         }
 

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -65,6 +65,16 @@ class CapabilitiesTable extends Table
     protected $_userActionCapabilities = [];
 
     /**
+     * Models that hold user information, usually used as associations to relate records to a user.
+     *
+     * @var array
+     */
+    protected $_assignationModels = [
+        'Users',
+        'CakeDC/Users.Users'
+    ];
+
+    /**
      * Initialize method
      *
      * @param array $config The configuration for the Table.

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -76,6 +76,7 @@ class RolesTable extends Table
     public function buildRules(RulesChecker $rules)
     {
         $rules->add($rules->isUnique(['name']));
+
         return $rules;
     }
 


### PR DESCRIPTION
This PR will provide the functionality of assigning owner capabilities.

The logic uses a Table's foreign keys which they associate it to a Users table. For example, fields like `assigned_to` or `owner`.

Using as an example controller Articles and action index (considerating the above logic). If you navigate to capabilities selection page, instead of seeing just the capability `Allow index`, you will get the following capabilities: `Allow index to all` and `Allow index if owner (assigned_to)`.

Now if you select just the `Allow index if owner (assigned_to)` capability and you navigate to the list of Articles, you should only be able to see the ones assigned to you.