### PR TITLE
Soft Delete (task #1396)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ sudo: false
 env:
   matrix:
     - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
 
@@ -19,12 +17,11 @@ matrix:
   fast_finish: true
 
 install:
-  - composer install 
+  - composer install
   - mkdir -p build/logs
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
 
 script:
   - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -18,10 +18,22 @@ Run plugin's migration task:
 bin/cake migrations migrate -p RolesCapabilities
 ```
 
-Load the plugin in your config/bootstrap.php file:
+Run required plugin(s) migration task:
 
 ```
-Plugin::load('RolesCapabilities', ['bootstrap' => true, 'routes' => true]);
+bin/cake migrations migrate -p Groups
+```
+
+## Setup
+Load plugin
+```
+bin/cake plugin load --routes --bootstrap RolesCapabilities
+```
+
+Load required plugin(s)
+```
+bin/cake plugin load Muffin/Trash
+bin/cake plugin load --routes --bootstrap CakeDC/Users
 ```
 
 Load the Capability component in your src/Controller/AppController.php file using the `initialize()` method. Additionally use the CapabilityTrait in AppController. See details below:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "php": ">=5.4.16",
         "cakephp/cakephp": "~3.0",
-        "qobo/cakephp-groups": "~1.0"
+        "qobo/cakephp-groups": "~1.0",
+        "muffin/trash": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/config/Migrations/20160916130609_AddTrashedToRoles.php
+++ b/config/Migrations/20160916130609_AddTrashedToRoles.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddTrashedToRoles extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('roles');
+        $table->addColumn('trashed', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->update();
+    }
+}

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -32,6 +32,7 @@ class RolesTable extends Table
         $this->primaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('Muffin/Trash.Trash');
 
         $this->hasMany('Capabilities', [
             'foreignKey' => 'role_id',


### PR DESCRIPTION
**Introducing soft delete functionality**
This means that no records will actually be dropped from the database. Instead, they will be flagged as `trashed` and will be skipped in `find()` queries.