### PR TITLE
System roles (task #3087)

### DIFF
--- a/config/Migrations/20161121145110_AddDenyEditDenyDeleteToRoles.php
+++ b/config/Migrations/20161121145110_AddDenyEditDenyDeleteToRoles.php
@@ -1,0 +1,26 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddDenyEditDenyDeleteToRoles extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('roles');
+        $table->addColumn('deny_edit', 'boolean', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->addColumn('deny_delete', 'boolean', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->update();
+    }
+}

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -4,6 +4,7 @@ namespace RolesCapabilities\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Core\App;
 use Cake\ORM\TableRegistry;
+use RolesCapabilities\Utility\Capability;
 
 class CapabilityComponent extends Component
 {
@@ -55,25 +56,13 @@ class CapabilityComponent extends Component
     }
 
     /**
-     * Method that retrieves all defined capabilities
-     *
-     * @return array capabilities
+     * @see RolesCapabilities\Utility\Capability::getAllCapabilities()
+     * @deprecated
+     * @return array
      */
     public function getAllCapabilities()
     {
-        $result = [];
-
-        foreach ($this->_getAllControllers() as $controller) {
-            if (is_callable([$controller, 'getCapabilities'])) {
-                foreach ($controller::getCapabilities($controller) as $type => $capabilities) {
-                    foreach ($capabilities as $capability) {
-                        $result[$controller][$capability->getName()] = $capability->getDescription();
-                    }
-                }
-            }
-        }
-
-        return $result;
+        return Capability::getAllCapabilities();
     }
 
     /**
@@ -134,55 +123,26 @@ class CapabilityComponent extends Component
     }
 
     /**
-     * Method that returns all controller names.
-     * @param  bool  $includePlugins flag for including plugin controllers
-     * @return array                 controller names
+     * @see RolesCapabilities\Utility\Capability::getControllers()
+     * @param  bool  $includePlugins flag for including plugin controllers.
+     * @deprecated
+     * @return array
      */
     protected function _getAllControllers($includePlugins = true)
     {
-        $controllers = $this->_getDirControllers(APP . 'Controller' . DS);
-
-        if (true === $includePlugins) {
-            $plugins = \Cake\Core\Plugin::loaded();
-            foreach ($plugins as $plugin) {
-                // plugin path
-                $path = \Cake\Core\Plugin::path($plugin) . 'src' . DS . 'Controller' . DS;
-                $controllers = array_merge($controllers, $this->_getDirControllers($path, $plugin));
-            }
-        }
-
-        return $controllers;
+        return Capability::getControllers();
     }
 
     /**
-     * Method that retrieves controller names
-     * found on the provided directory path.
+     * @see RolesCapabilities\Utility\Capability::getDirControllers()
      * @param  string $path   directory path
      * @param  string $plugin plugin name
      * @param  bool   $fqcn   flag for using fqcn
-     * @return array          controller names
+     * @deprecated
+     * @return array
      */
     protected function _getDirControllers($path, $plugin = null, $fqcn = true)
     {
-        $controllers = [];
-        if (file_exists($path)) {
-            $dir = new \DirectoryIterator($path);
-            foreach ($dir as $fileinfo) {
-                $className = $fileinfo->getBasename('.php');
-                if ($fileinfo->isFile() && 'AppController' !== $className) {
-                    if (!empty($plugin)) {
-                        $className = $plugin . '.' . $className;
-                    }
-
-                    if (true === $fqcn) {
-                        $className = App::className($className, 'Controller');
-                    }
-
-                    $controllers[] = $className;
-                }
-            }
-        }
-
-        return $controllers;
+        return Capability::getDirControllers();
     }
 }

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -78,6 +78,16 @@ class RolesTable extends Table
     {
         $rules->add($rules->isUnique(['name']));
 
+        // don't allow editing of non-editable role(s)
+        $rules->addUpdate(function ($entity, $options) {
+            return !$entity->deny_edit;
+        }, 'systemCheck');
+
+        // don't allow deletion of non-deletable role(s)
+        $rules->addDelete(function ($entity, $options) {
+            return !$entity->deny_delete;
+        }, 'systemCheck');
+
         return $rules;
     }
 

--- a/src/Shell/CapabilityShell.php
+++ b/src/Shell/CapabilityShell.php
@@ -1,0 +1,35 @@
+<?php
+namespace RolesCapabilities\Shell;
+
+use Cake\Console\ConsoleOptionParser;
+use Cake\Console\Shell;
+
+class CapabilityShell extends Shell
+{
+    /**
+     * {@inheritDoc}
+     */
+    public $tasks = [
+        'RolesCapabilities.Assign'
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        $parser
+            ->description('Roles Shell that handle\'s related tasks.')
+            ->addSubcommand(
+                'assign',
+                [
+                    'help' => 'Assign all capabilities to \'Admins\' role.',
+                    'parser' => $this->Assign->getOptionParser()
+                ]
+            );
+
+        return $parser;
+    }
+}

--- a/src/Shell/RoleShell.php
+++ b/src/Shell/RoleShell.php
@@ -1,0 +1,32 @@
+<?php
+namespace RolesCapabilities\Shell;
+
+use Cake\Console\ConsoleOptionParser;
+use Cake\Console\Shell;
+
+class RoleShell extends Shell
+{
+    /**
+     * {@inheritDoc}
+     */
+    public $tasks = [
+        'RolesCapabilities.Import'
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        $parser
+            ->description('Roles Shell that handle\'s related tasks.')
+            ->addSubcommand(
+                'import',
+                ['help' => 'Import system role(s).', 'parser' => $this->Import->getOptionParser()]
+            );
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -1,0 +1,126 @@
+<?php
+namespace RolesCapabilities\Shell\Task;
+
+use Cake\Console\Shell;
+use Cake\Core\Configure;
+use Cake\ORM\Entity;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Task for importing system roles.
+ */
+class ImportTask extends Shell
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function main()
+    {
+        $this->out('Task: import system role(s)');
+        $this->hr();
+
+        // get roles table
+        $table = TableRegistry::get('RolesCapabilities.Roles');
+
+        $roles = $this->_getSystemRoles();
+        if ($roles) {
+            foreach ($roles as $role) {
+                $entity = $table->newEntity();
+                foreach ($role as $k => $v) {
+                    $entity->{$k} = $v;
+                }
+
+                if ($table->save($entity)) {
+                    $msg = 'Role [' . $entity->name . '] imported';
+                    // associate imported role with matching group
+                    $group = $this->_getGroupByRoleName($entity->name);
+                    if ($table->Groups->link($entity, [$group])) {
+                        $msg .= ' and associated with group [' . $group->name . ']';
+                    }
+                    $msg .= ' successfully';
+
+                    $this->out('<info>' . $msg . '</info>');
+                } else {
+                    $this->err('Failed to import role [' . $entity->name . ']');
+                    $errors = $this->_getImportErrors($entity);
+                    if (!empty($errors)) {
+                        $this->out(implode("\n", $errors));
+                        $this->hr();
+                    }
+                }
+            }
+        }
+
+        $this->out('<success>System roles(s) importing task completed</success>');
+    }
+
+    /**
+     * Get system roles.
+     *
+     * @return string|null
+     */
+    protected function _getSystemRoles()
+    {
+        $result = [
+            [
+                'name' => 'Admins',
+                'description' => 'Administrators role',
+                'deny_edit' => true,
+                'deny_delete' => true
+            ],
+            [
+                'name' => 'Everyone',
+                'description' => 'Generic role',
+                'deny_edit' => false,
+                'deny_delete' => true
+            ]
+        ];
+
+        if (empty($result)) {
+            $this->err('System role(s) are not defined, all following tasks are skipped');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fetch group entity based on role name. Abort if not found.
+     *
+     * @param  string $name Role name
+     * @return \Cake\ORM\Entity
+     */
+    protected function _getGroupByRoleName($name)
+    {
+        $result = TableRegistry::get('Groups.Groups')->findByName($name)->first();
+
+        if (!$result) {
+            $this->abort('Failed fetching group [' . $name . '], please make sure it exists.');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get import errors from entity object.
+     *
+     * @param  \Cake\ORM\Entity $entity Entity instance
+     * @return array
+     */
+    protected function _getImportErrors($entity)
+    {
+        $result = [];
+        if (!empty($entity->errors())) {
+            foreach ($entity->errors() as $field => $error) {
+                if (is_array($error)) {
+                    $msg = implode(', ', $error);
+                } else {
+                    $msg = $errors;
+                }
+                $result[] = $msg . ' [' . $field . ']';
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Template/Roles/index.ctp
+++ b/src/Template/Roles/index.ctp
@@ -38,8 +38,12 @@
                         </td>
                         <td class="actions">
                             <?= $this->Html->link('', ['action' => 'view', $role->id], ['title' => __('View'), 'class' => 'btn btn-default glyphicon glyphicon-eye-open']) ?>
-                            <?= $this->Html->link('', ['action' => 'edit', $role->id], ['title' => __('View'), 'class' => 'btn btn-default glyphicon glyphicon-pencil']) ?>
-                            <?= $this->Form->postLink('', ['action' => 'delete', $role->id], ['confirm' => __('Are you sure you want to delete # {0}?', $role->id), 'title' => __('Delete'), 'class' => 'btn btn-default glyphicon glyphicon-trash']) ?>
+                            <?php if (!$role->deny_edit) : ?>
+                                <?= $this->Html->link('', ['action' => 'edit', $role->id], ['title' => __('View'), 'class' => 'btn btn-default glyphicon glyphicon-pencil']) ?>
+                            <?php endif; ?>
+                            <?php if (!$role->deny_delete) : ?>
+                                <?= $this->Form->postLink('', ['action' => 'delete', $role->id], ['confirm' => __('Are you sure you want to delete # {0}?', $role->id), 'title' => __('Delete'), 'class' => 'btn btn-default glyphicon glyphicon-trash']) ?>
+                            <?php endif; ?>
                         </td>
                     </tr>
                     <?php endforeach; ?>

--- a/src/Utility/Capability.php
+++ b/src/Utility/Capability.php
@@ -1,0 +1,83 @@
+<?php
+namespace RolesCapabilities\Utility;
+
+use Cake\Core\App;
+use Cake\Core\Plugin;
+use DirectoryIterator;
+
+class Capability
+{
+    /**
+     * Method that retrieves all capabilities.
+     *
+     * @return array capabilities
+     */
+    public function getAllCapabilities()
+    {
+        $result = [];
+        foreach (self::getControllers() as $controller) {
+            if (is_callable([$controller, 'getCapabilities'])) {
+                foreach ($controller::getCapabilities($controller) as $type => $capabilities) {
+                    foreach ($capabilities as $capability) {
+                        $result[$controller][$capability->getName()] = $capability->getDescription();
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Method that returns all controller names.
+     * @param  bool  $includePlugins flag for including plugin controllers
+     * @return array                 controller names
+     */
+    public static function getControllers($includePlugins = true)
+    {
+        $controllers = self::getDirControllers(APP . 'Controller' . DS);
+
+        if (true === $includePlugins) {
+            $plugins = Plugin::loaded();
+            foreach ($plugins as $plugin) {
+                // plugin path
+                $path = Plugin::path($plugin) . 'src' . DS . 'Controller' . DS;
+                $controllers = array_merge($controllers, self::getDirControllers($path, $plugin));
+            }
+        }
+
+        return $controllers;
+    }
+
+    /**
+     * Method that retrieves controller names
+     * found on the provided directory path.
+     * @param  string $path   directory path
+     * @param  string $plugin plugin name
+     * @param  bool   $fqcn   flag for using fqcn
+     * @return array          controller names
+     */
+    public static function getDirControllers($path, $plugin = null, $fqcn = true)
+    {
+        $controllers = [];
+        if (file_exists($path)) {
+            $dir = new DirectoryIterator($path);
+            foreach ($dir as $fileinfo) {
+                $className = $fileinfo->getBasename('.php');
+                if ($fileinfo->isFile() && 'AppController' !== $className) {
+                    if (!empty($plugin)) {
+                        $className = $plugin . '.' . $className;
+                    }
+
+                    if (true === $fqcn) {
+                        $className = App::className($className, 'Controller');
+                    }
+
+                    $controllers[] = $className;
+                }
+            }
+        }
+
+        return $controllers;
+    }
+}


### PR DESCRIPTION
Defined system roles `Admins` and `Everyone`. Both roles are not deletable and `Admins` is not editable.

To import these roles please run the following shell task:
```bash
bin/cake role import
```
During import roles are assigned to their respective groups, if the groups are not found the task will abort. To avoid this please first run the following shell task:
```bash
bin/cake group import
```

To assign all capabilities to `Admins` role please run the following shell task:
```bash
bin/cake capability assign
```