### PR TITLE
Bugfix on record access check (task #3267)

### DIFF
--- a/src/Event/ModelBeforeFindEventsListener.php
+++ b/src/Event/ModelBeforeFindEventsListener.php
@@ -105,6 +105,17 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
         // @todo currently we are always assume index action, this probably needs to change in the future
         $actionCapabilities = $aclTable->getCapabilities($controllerName, ['index']);
 
+        $fullType = $aclTable->getTypeFull();
+        // check user capabilities against action's full capabilities
+        if (isset($actionCapabilities[$fullType])) {
+            foreach ($actionCapabilities[$fullType] as $capability) {
+                // if current action's full capability is matched in user's capabilities just return
+                if (in_array($capability->getName(), $userCapabilities)) {
+                    return;
+                }
+            }
+        }
+
         // check if user has owner capability for current action,
         // if it does modify the query accordingly and return.
         $ownerType = $aclTable->getTypeOwner();
@@ -122,17 +133,6 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
 
             if ($hasOwnerType) {
                 return;
-            }
-        }
-
-        $fullType = $aclTable->getTypeFull();
-        // check user capabilities against action's full capabilities
-        if (isset($actionCapabilities[$fullType])) {
-            foreach ($actionCapabilities[$fullType] as $capability) {
-                // if current action's full capability is matched in user's capabilities just return
-                if (in_array($capability->getName(), $userCapabilities)) {
-                    return;
-                }
             }
         }
 


### PR DESCRIPTION
Currently, we first check if the user has owner type capabilities to the current action and we modify the query accordingly.

This breaks the expected behavior for users like admins. Admins, by default, are assigned all system capabilities. Since we are first checking for owner type capabilities, we modify the query to return only records owned (assigned) to the user, which is wrong.

To fix the issue explained above, we change the order of the checks to firstly check for full access type capabilities, and if the user has such access we just skip modifying the query altogether.