### PR TITLE
Fixed incorrect label in view

### DIFF
--- a/src/Template/Roles/view.ctp
+++ b/src/Template/Roles/view.ctp
@@ -1,6 +1,6 @@
 <section class="content-header">
     <h1><?= $this->Html->link(
-        __('Users'),
+        __('Roles'),
         ['plugin' => 'RolesCapabilities', 'controller' => 'Roles', 'action' => 'index']
     ) . ' &raquo; ' . h($role->name) ?></h1>
 </section>


### PR DESCRIPTION
Probably this was a copy-paste error from the times of AdminLTE
migration.  Viewing a single role was refering to 'Users' at the
top instead of 'Roles'.  The link was correct, just the label is
wrong.