### PR TITLE
Cleanup permissions (task #3205)

### DIFF
--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -90,16 +90,6 @@ trait CapabilityTrait
     }
 
     /**
-     * Get list of Cake's Controller class methods.
-     *
-     * @return array
-     */
-    protected static function _getCakeControllerActions()
-    {
-        return static::_getCapabilitiesTable()->getCakeControllerActions();
-    }
-
-    /**
      * Get list of skipped controllers.
      *
      * @return array

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -122,18 +122,6 @@ trait CapabilityTrait
     }
 
     /**
-     * Generate capability label.
-     *
-     * @param  string $controllerName Controller name
-     * @param  string $action         Action name
-     * @return string
-     */
-    protected static function _generateCapabilityLabel($controllerName, $action)
-    {
-        return static::_getCapabilitiesTable()->generateCapabilityLabel($controllerName, $action);
-    }
-
-    /**
      * Generate capability description.
      *
      * @param  string $controllerName Controller name

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -109,15 +109,4 @@ trait CapabilityTrait
     {
         return static::_getCapabilitiesTable()->getSkipActions($controllerName);
     }
-
-    /**
-     * Generate capability's controller name.
-     *
-     * @param  string $controllerName Controller name
-     * @return string
-     */
-    protected static function _generateCapabilityControllerName($controllerName)
-    {
-        return static::_getCapabilitiesTable()->generateCapabilityControllerName($controllerName);
-    }
 }

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -120,16 +120,4 @@ trait CapabilityTrait
     {
         return static::_getCapabilitiesTable()->generateCapabilityControllerName($controllerName);
     }
-
-    /**
-     * Generate capability description.
-     *
-     * @param  string $controllerName Controller name
-     * @param  string $action         Action name
-     * @return string
-     */
-    protected static function _generateCapabilityDescription($controllerName, $action)
-    {
-        return static::_getCapabilitiesTable()->generateCapabilityDescription($controllerName, $action);
-    }
 }

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -100,17 +100,6 @@ trait CapabilityTrait
     }
 
     /**
-     * Get list of skipped controllers.
-     *
-     * @deprecated
-     * @return array
-     */
-    protected static function _getSkipControllers()
-    {
-        return static::getSkipControllers();
-    }
-
-    /**
      * Get list of controller's skipped actions.
      *
      * @param  string $controllerName Controller name

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -122,18 +122,6 @@ trait CapabilityTrait
     }
 
     /**
-     * Generate capability name.
-     *
-     * @param  string $controllerName Controller name
-     * @param  string $action         Action name
-     * @return string
-     */
-    protected static function _generateCapabilityName($controllerName, $action)
-    {
-        return static::_getCapabilitiesTable()->generateCapabilityName($controllerName, $action);
-    }
-
-    /**
      * Generate capability label.
      *
      * @param  string $controllerName Controller name

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -111,18 +111,6 @@ trait CapabilityTrait
     }
 
     /**
-     * Get list of controller's skipped actions.
-     *
-     * @param  string $controllerName Controller name
-     * @deprecated
-     * @return array
-     */
-    protected static function _getSkipActions($controllerName)
-    {
-        return static::getSkipActions($controllerName);
-    }
-
-    /**
      * Generate capability's controller name.
      *
      * @param  string $controllerName Controller name

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -101,17 +101,6 @@ class CapabilityComponent extends Component
     }
 
     /**
-     * Method that retrieves specified user's capabilities
-     * @param  string $userId user id
-     * @deprecated
-     * @return array
-     */
-    protected function _getUserCapabilities($userId)
-    {
-        return $this->_capabilitiesTable->getUserCapabilities($userId);
-    }
-
-    /**
      * Method that retrieves specified group(s) roles.
      * @param  array  $userGroups group(s) id(s)
      * @deprecated

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -101,17 +101,6 @@ class CapabilityComponent extends Component
     }
 
     /**
-     * @see RolesCapabilities\Utility\Capability::getControllers()
-     * @param  bool  $includePlugins flag for including plugin controllers.
-     * @deprecated
-     * @return array
-     */
-    protected function _getAllControllers($includePlugins = true)
-    {
-        return Capability::getControllers();
-    }
-
-    /**
      * @see RolesCapabilities\Utility\Capability::getDirControllers()
      * @param  string $path   directory path
      * @param  string $plugin plugin name

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -101,17 +101,6 @@ class CapabilityComponent extends Component
     }
 
     /**
-     * Method that retrieves specified group(s) roles.
-     * @param  array  $userGroups group(s) id(s)
-     * @deprecated
-     * @return array
-     */
-    protected function _getGroupsRoles(array $userGroups = [])
-    {
-        return $this->_capabilitiesTable->getGroupsRoles($userGroups);
-    }
-
-    /**
      * @see RolesCapabilities\Utility\Capability::getControllers()
      * @param  bool  $includePlugins flag for including plugin controllers.
      * @deprecated

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -99,17 +99,4 @@ class CapabilityComponent extends Component
 
         return $this->_capabilitiesTable->hasRoleAccess($roleId, $userId);
     }
-
-    /**
-     * @see RolesCapabilities\Utility\Capability::getDirControllers()
-     * @param  string $path   directory path
-     * @param  string $plugin plugin name
-     * @param  bool   $fqcn   flag for using fqcn
-     * @deprecated
-     * @return array
-     */
-    protected function _getDirControllers($path, $plugin = null, $fqcn = true)
-    {
-        return Capability::getDirControllers();
-    }
 }


### PR DESCRIPTION
Removed a few obsolete and deprecated protected methods from `src/CapabilityTrait`:

* `_getCakeControllerActions()`
* `_getSkipControllers()`
* `_getSkipActions()`
* `_generateCapabilityName()`
* `_generateCapabilityLabel()`
* `_generateCapabilityDescription()`
* `_generateCapabilityControllerName()`

Removed a few obsolete and deprecated protected methods from `src/Controller/Component/CapabilityComponent.php`:

* `_getUserCapabilities()`
* `_getGroupsRoles()`
* `_getAllControllers()`
* `_getDirControllers()`