### PR TITLE
Added checking parent modules acess - task #4178

### DIFF
--- a/src/Access/CapabilitiesAccess.php
+++ b/src/Access/CapabilitiesAccess.php
@@ -5,6 +5,7 @@ namespace RolesCapabilities\Access;
 use Cake\Core\App;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
 use ReflectionClass;
 use ReflectionMethod;
 use RolesCapabilities\Access\Utils;
@@ -74,6 +75,46 @@ class CapabilitiesAccess extends AuthenticatedAccess
         $hasAccess = Utils::hasTypeAccess(Utils::getTypeOwner(), $actionCapabilities, $user, $url);
         if ($hasAccess) {
             return true;
+        }
+
+        $hasAccess = $this->_hasParentAccess($url, $user);
+        if ($hasAccess) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     *  _hasParentAccess method
+     *
+     * @param array $url    request URL
+     * @param array $user   user's session data
+     * @return bool         true or false
+     */
+    private function _hasParentAccess($url, $user)
+    {
+        $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MODULE, Inflector::camelize($url['controller']));
+        $moduleConfig = (array)json_decode(json_encode($mc->parse()), true);
+
+        $parents = $moduleConfig['table']['parent_modules'];
+        foreach ($parents as $parent) {
+            $parentUrl = $url;
+            $parentUrl['controller'] = $parent;
+
+            $controllerName = Utils::getControllerFullName($parentUrl);
+            $actionCapabilities = Utils::getCapabilities($controllerName, [$parentUrl['action']]);
+
+            $hasAccess = Utils::hasTypeAccess(Utils::getTypeOwner(), $actionCapabilities, $user, $parentUrl);
+            if ($hasAccess) {
+                return true;
+            }
+
+            // if user has no full access capabilities
+            $hasAccess = Utils::hasTypeAccess(Utils::getTypeOwner(), $actionCapabilities, $user, $parentUrl);
+            if ($hasAccess) {
+                return true;
+            }
         }
 
         return false;

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -31,6 +31,11 @@ class Utils
     const CAP_TYPE_OWNER = 'owner';
 
     /**
+     * Parent type capability identifier
+     */
+    const CAP_TYPE_PARENT = 'parent';
+
+    /**
      * Non-assigned actions
      *
      * @var array


### PR DESCRIPTION
Example:
config/Modules/Contacts/config/config.ini
```
[table]
icon = user
searchable = true
display_field = name
typeahead_fields = first_name,last_name,company_name,email
basic_search_fields = first_name,last_name,company_name,email,phone
parent_modules = Leads,Accounts
```
