### PR TITLE
Parent fetch capability (task #4178)

### DIFF
--- a/src/Access/CapabilitiesAccess.php
+++ b/src/Access/CapabilitiesAccess.php
@@ -92,32 +92,14 @@ class CapabilitiesAccess extends AuthenticatedAccess
      * @param array $user   user's session data
      * @return bool         true or false
      */
-    private function _hasParentAccess($url, $user)
+    protected function _hasParentAccess($url, $user)
     {
         $mc = new ModuleConfig(ModuleConfig::CONFIG_TYPE_MODULE, Inflector::camelize($url['controller']));
         $moduleConfig = (array)json_decode(json_encode($mc->parse()), true);
 
         $parents = $moduleConfig['table']['parent_modules'];
-        foreach ($parents as $parent) {
-            $parentUrl = $url;
-            $parentUrl['controller'] = $parent;
 
-            $controllerName = Utils::getControllerFullName($parentUrl);
-            $actionCapabilities = Utils::getCapabilities($controllerName, [$parentUrl['action']]);
-
-            $hasAccess = Utils::hasTypeAccess(Utils::getTypeOwner(), $actionCapabilities, $user, $parentUrl);
-            if ($hasAccess) {
-                return true;
-            }
-
-            // if user has no full access capabilities
-            $hasAccess = Utils::hasTypeAccess(Utils::getTypeOwner(), $actionCapabilities, $user, $parentUrl);
-            if ($hasAccess) {
-                return true;
-            }
-        }
-
-        return false;
+        return !empty($parents);
     }
 
     /**

--- a/src/Access/CapabilitiesAccess.php
+++ b/src/Access/CapabilitiesAccess.php
@@ -40,6 +40,14 @@ class CapabilitiesAccess extends AuthenticatedAccess
     protected $_userCapabilities = [];
 
     /**
+     * Parent Access logic targeted actions.
+     *
+     * @var array
+     * @todo This is a temporary fix until proper model / controller specific capabilities are implemented.
+     */
+    protected $_parentAccessActions = ['index', 'view'];
+
+    /**
      *  CheckAccess Capabilities
      *
      * @param array $url    request URL
@@ -77,9 +85,11 @@ class CapabilitiesAccess extends AuthenticatedAccess
             return true;
         }
 
-        $hasAccess = $this->_hasParentAccess($url, $user);
-        if ($hasAccess) {
-            return true;
+        if (in_array($url['action'], $this->_parentAccessActions)) {
+            $hasAccess = $this->_hasParentAccess($url, $user);
+            if ($hasAccess) {
+                return true;
+            }
         }
 
         return false;

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -90,6 +90,16 @@ class Utils
     }
 
     /**
+     * Get parent type capability identifier.
+     *
+     * @return string
+     */
+    public static function getTypeParent()
+    {
+        return static::CAP_TYPE_PARENT;
+    }
+
+    /**
      * Method that retrieves and returns Controller public methods.
      *
      * @param  string $controllerName Controller name

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -390,13 +390,11 @@ class Utils
     {
         $result = [];
         foreach (self::getControllers() as $controller) {
-            if (is_callable([$controller, 'getCapabilities'])) {
-                foreach ($controller::getCapabilities($controller) as $type => $capabilities) {
-                    foreach ($capabilities as $capability) {
-                        $result[$controller][$capability->getName()] = $capability->getDescription();
-                    }
-                }
+            if (!is_callable([$controller, 'getCapabilities'])) {
+                continue;
             }
+
+            $result[$controller] = $controller::getCapabilities($controller);
         }
 
         return $result;

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -198,17 +198,11 @@ class Utils
      */
     public static function getControllerTableInstance($controllerName)
     {
-        $parts = explode('\\', $controllerName);
-        // get last part, "/ArticlesController"
-        $tableName = array_pop($parts);
-        // remove "Controller" suffix from "/ArticlesController"
-        $tableName = str_replace('Controller', '', $tableName);
-        array_pop($parts);
-        // get plugin part "/MyPlugin/"
-        $plugin = array_pop($parts);
-        // prefix plugin to table name if is not "App"
-        if ('App' !== $plugin) {
-            $tableName = $plugin . '.' . $tableName;
+        $tableName = App::shortName($controllerName, 'Controller', 'Controller');
+
+        // remove vendor prefix
+        if (false !== strpos($tableName, '/')) {
+            $tableName = substr($tableName, strpos($tableName, '/') + 1);
         }
 
         return TableRegistry::get($tableName);

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -307,7 +307,7 @@ class Utils
      * @param  array  $assignationFields Table assignation fields (example: assigned_to)
      * @return array
      */
-    public static function getCapabilitiesForAction($controllerName, array $actions, array $assignationFields = [])
+    public static function getCapabilitiesForAction($controllerName, array $actions, array $assignationFields)
     {
         $key = implode('.', $actions);
 
@@ -479,13 +479,15 @@ class Utils
         }
 
         // get controller table instance
-        $controllerTable = static::getControllerTableInstance($controllerName);
+        $table = static::getControllerTableInstance($controllerName);
 
-        return static::getCapabilitiesForAction(
+        $result = static::getCapabilitiesForAction(
             static::generateCapabilityControllerName($controllerName),
             $actions,
-            static::getTableAssignationFields($controllerTable)
+            static::getTableAssignationFields($table)
         );
+
+        return $result;
     }
 
     /**

--- a/src/Capability.php
+++ b/src/Capability.php
@@ -40,6 +40,12 @@ class Capability
     protected $_field;
 
     /**
+     * Capability parent modules
+     * @var array
+     */
+    protected $_parentModules = [];
+
+    /**
      * Constructor method
      * @param string $name    Capability name
      * @param array  $options Capability options
@@ -57,6 +63,10 @@ class Capability
 
         if (isset($options['field'])) {
             $this->setField($options['field']);
+        }
+
+        if (isset($options['parent_modules'])) {
+            $this->setParentModules($options['parent_modules']);
         }
     }
 
@@ -156,5 +166,28 @@ class Capability
     public function getField()
     {
         return $this->_field;
+    }
+
+    /**
+     * Set parent module(s)
+     *
+     * @param string $parentModules Capability parent module(s)
+     * @return Capability
+     */
+    public function setParentModules($parentModules)
+    {
+        $this->_parentModules = $parentModules;
+
+        return $this;
+    }
+
+    /**
+     * Get parent module(s)
+     *
+     * @return array
+     */
+    public function getParentModules()
+    {
+        return $this->_parentModules;
     }
 }

--- a/src/Controller/RolesController.php
+++ b/src/Controller/RolesController.php
@@ -32,10 +32,12 @@ class RolesController extends AppController
     public function view($id = null)
     {
         $role = $this->Roles->get($id, [
-            'contain' => ['Groups', 'Capabilities']
+            'contain' => ['Groups']
         ]);
+        $roleCaps = $this->Roles->Capabilities->find('list')->where(['role_id' => $id])->toArray();
         $capabilities = $this->Capability->getAllCapabilities();
         $this->set('capabilities', $capabilities);
+        $this->set('roleCaps', $roleCaps);
         $this->set('role', $role);
         $this->set('_serialize', ['role']);
     }

--- a/src/Event/ModelBeforeFindEventsListener.php
+++ b/src/Event/ModelBeforeFindEventsListener.php
@@ -140,14 +140,14 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
      */
     protected function _hasFullAccess(array $actionCaps, array $userCaps)
     {
-        $fullType = Utils::getTypeFull();
+        $type = Utils::getTypeFull();
 
-        if (!isset($actionCaps[$fullType])) {
+        if (!isset($actionCaps[$type])) {
             return false;
         }
 
         // check user capabilities against action's full capabilities
-        foreach ($actionCaps[$fullType] as $actionCap) {
+        foreach ($actionCaps[$type] as $actionCap) {
             // if current action's full capability is matched in user's capabilities just return
             if (in_array($actionCap->getName(), $userCaps)) {
                 return true;
@@ -169,13 +169,13 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
     {
         $result = [];
 
-        $ownerType = Utils::getTypeOwner();
-        if (!isset($actionCaps[$ownerType])) {
+        $type = Utils::getTypeOwner();
+        if (!isset($actionCaps[$type])) {
             return $result;
         }
 
         // check user capabilities against action's owner capabilities
-        foreach ($actionCaps[$ownerType] as $capability) {
+        foreach ($actionCaps[$type] as $capability) {
             if (!in_array($capability->getName(), $userCaps)) {
                 continue;
             }

--- a/src/Event/ModelBeforeFindEventsListener.php
+++ b/src/Event/ModelBeforeFindEventsListener.php
@@ -129,12 +129,12 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
 
         $joins = $this->_getParentJoins($table, $actionCaps, $user, $userCaps);
         if (!empty($joins)) {
-            foreach ($joins as $name => $params) {
+            foreach ($joins as $name => $conditions) {
                 $query->leftJoinWith($name, function ($q) {
                     return $q->applyOptions(['accessCheck' => false]);
                 });
 
-                $where = array_merge($where, $params['where']);
+                $where = array_merge($where, $conditions);
             }
         }
 
@@ -297,16 +297,13 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
                 continue;
             }
 
-            $where = [];
+            $conditions = [];
             foreach ($fields as $field) {
-                $where[$targetTable->aliasField($field)] = $user['id'];
+                $conditions[$targetTable->aliasField($field)] = $user['id'];
             }
 
             $foreignKey = $targetTable->aliasField($association->getForeignKey());
-            $result[$association->getName()] = [
-                'conditions' => $foreignKey . ' = ' . $primaryKey,
-                'where' => $where
-            ];
+            $result[$association->getName()] = $conditions;
         }
 
         return $result;

--- a/src/Event/ModelBeforeFindEventsListener.php
+++ b/src/Event/ModelBeforeFindEventsListener.php
@@ -292,7 +292,6 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
                 continue;
             }
 
-
             $fields = Utils::getTableAssignationFields($targetTable);
             if (empty($fields)) {
                 continue;

--- a/src/Template/Roles/add.ctp
+++ b/src/Template/Roles/add.ctp
@@ -69,6 +69,11 @@ echo $this->Html->scriptBlock(
         <div class="box-body">
             <div class="row">
             <?php ksort($capabilities); foreach ($capabilities as $groupName => $groupCaps) : ?>
+                <?php
+                if (empty($groupCaps)) {
+                    continue;
+                }
+                ?>
                 <?php if ($count > $maxNum) : ?>
                     </div>
                     <div class="row">

--- a/src/Template/Roles/add.ctp
+++ b/src/Template/Roles/add.ctp
@@ -80,8 +80,8 @@ echo $this->Html->scriptBlock(
                     <?php $count = 0; ?>
                 <?php endif; ?>
                 <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-                    <div class="box box-default permission-box collapsed-box">
-                        <div class="box-header with-border">
+                    <div class="box box-default box-solid permission-box collapsed-box">
+                        <div class="box-header">
                             <h3 class="box-title"><?= $this->cell('RolesCapabilities.Capability::groupName', [$groupName]) ?></h3>
                             <div class="box-tools pull-right">
                                 <button class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>

--- a/src/Template/Roles/add.ctp
+++ b/src/Template/Roles/add.ctp
@@ -1,4 +1,6 @@
 <?php
+use Cake\Utility\Inflector;
+
 echo $this->Html->css(
     [
         'AdminLTE./plugins/select2/select2.min',
@@ -48,7 +50,7 @@ echo $this->Html->scriptBlock(
             </div>
         </div>
     </div>
-    <div class="box box-default">
+    <div class="box box-solid">
         <div class="box-header with-border">
             <h3 class="box-title"><?= __('Capabilities') ?></h3>
             <div class="box-tools pull-right">
@@ -91,13 +93,19 @@ echo $this->Html->scriptBlock(
                                 'label' => __('Select All'),
                             ]);
                             echo $this->Html->tag('hr');
-                            asort($groupCaps);
-                            foreach ($groupCaps as $k => $v) {
-                                echo $this->Form->input('capabilities[_names][' . $k . ']', [
-                                    'type' => 'checkbox',
-                                    'label' => $v,
-                                    'div' => false
-                                ]);
+
+                            foreach ($groupCaps as $type => $caps) {
+                                usort($caps, function ($a, $b) {
+                                    return strcmp($a->getDescription(), $b->getDescription());
+                                });
+                                echo $this->Html->tag('h4', Inflector::humanize($type) . ' ' . __('Access'));
+                                foreach ($caps as $cap) {
+                                    echo $this->Form->input('capabilities[_names][' . $cap->getName() . ']', [
+                                        'type' => 'checkbox',
+                                        'label' => $cap->getDescription(),
+                                        'div' => false
+                                    ]);
+                                }
                             }
                             ?>
                         </div>

--- a/src/Template/Roles/edit.ctp
+++ b/src/Template/Roles/edit.ctp
@@ -1,4 +1,6 @@
 <?php
+use Cake\Utility\Inflector;
+
 echo $this->Html->css(
     [
         'AdminLTE./plugins/select2/select2.min',
@@ -48,7 +50,7 @@ echo $this->Html->scriptBlock(
             </div>
         </div>
     </div>
-    <div class="box box-default">
+    <div class="box box-solid">
         <div class="box-header with-border">
             <h3 class="box-title"><?= __('Capabilities') ?></h3>
             <div class="box-tools pull-right">
@@ -91,14 +93,20 @@ echo $this->Html->scriptBlock(
                                 'label' => __('Select All'),
                             ]);
                             echo $this->Html->tag('hr');
-                            asort($groupCaps);
-                            foreach ($groupCaps as $k => $v) {
-                                echo $this->Form->input('capabilities[_names][' . $k . ']', [
-                                    'type' => 'checkbox',
-                                    'label' => $v,
-                                    'div' => false,
-                                    'checked' => in_array($k, $roleCaps)
-                                ]);
+
+                            foreach ($groupCaps as $type => $caps) {
+                                usort($caps, function ($a, $b) {
+                                    return strcmp($a->getDescription(), $b->getDescription());
+                                });
+                                echo $this->Html->tag('h4', Inflector::humanize($type) . ' ' . __('Access'));
+                                foreach ($caps as $cap) {
+                                    echo $this->Form->input('capabilities[_names][' . $cap->getName() . ']', [
+                                        'type' => 'checkbox',
+                                        'label' => $cap->getDescription(),
+                                        'div' => false,
+                                        'checked' => in_array($cap->getName(), $roleCaps)
+                                    ]);
+                                }
                             }
                             ?>
                         </div>

--- a/src/Template/Roles/edit.ctp
+++ b/src/Template/Roles/edit.ctp
@@ -69,6 +69,11 @@ echo $this->Html->scriptBlock(
         <div class="box-body">
             <div class="row">
             <?php ksort($capabilities); foreach ($capabilities as $groupName => $groupCaps) : ?>
+                <?php
+                if (empty($groupCaps)) {
+                    continue;
+                }
+                ?>
                 <?php if ($count > $maxNum) : ?>
                     </div>
                     <div class="row">

--- a/src/Template/Roles/edit.ctp
+++ b/src/Template/Roles/edit.ctp
@@ -80,8 +80,8 @@ echo $this->Html->scriptBlock(
                     <?php $count = 0; ?>
                 <?php endif; ?>
                 <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-                    <div class="box box-default permission-box collapsed-box">
-                        <div class="box-header with-border">
+                    <div class="box box-default box-solid permission-box collapsed-box">
+                        <div class="box-header">
                             <h3 class="box-title"><?= $this->cell('RolesCapabilities.Capability::groupName', [$groupName]) ?></h3>
                             <div class="box-tools pull-right">
                                 <button class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>

--- a/src/Template/Roles/view.ctp
+++ b/src/Template/Roles/view.ctp
@@ -53,6 +53,11 @@ use Cake\Utility\Inflector;
                     <div role="tabpanel" class="tab-pane active" id="capabilities">
                         <div class="row">
                             <?php ksort($capabilities); foreach ($capabilities as $groupName => $groupCaps) : ?>
+                            <?php
+                            if (empty($groupCaps)) {
+                                continue;
+                            }
+                            ?>
                             <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
                                 <div class="box box-default permission-box collapsed-box">
                                     <div class="box-header with-border">

--- a/src/Template/Roles/view.ctp
+++ b/src/Template/Roles/view.ctp
@@ -68,8 +68,8 @@ use Cake\Utility\Inflector;
                                 <?php $count = 0; ?>
                             <?php endif; ?>
                             <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-                                <div class="box box-default permission-box collapsed-box">
-                                    <div class="box-header with-border">
+                                <div class="box box-default box-solid permission-box collapsed-box">
+                                    <div class="box-header">
                                         <h3 class="box-title"><?= $this->cell('RolesCapabilities.Capability::groupName', [$groupName]) ?></h3>
                                         <div class="box-tools pull-right">
                                             <button class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>

--- a/src/Template/Roles/view.ctp
+++ b/src/Template/Roles/view.ctp
@@ -49,15 +49,24 @@ use Cake\Utility\Inflector;
                         </a>
                     </li>
                 </ul>
+                <?php
+                    $count = 0;
+                    $maxNum = 3;
+                ?>
                 <div class="tab-content">
                     <div role="tabpanel" class="tab-pane active" id="capabilities">
                         <div class="row">
-                            <?php ksort($capabilities); foreach ($capabilities as $groupName => $groupCaps) : ?>
+                        <?php ksort($capabilities); foreach ($capabilities as $groupName => $groupCaps) : ?>
                             <?php
                             if (empty($groupCaps)) {
                                 continue;
                             }
                             ?>
+                            <?php if ($count > $maxNum) : ?>
+                                </div>
+                                <div class="row">
+                                <?php $count = 0; ?>
+                            <?php endif; ?>
                             <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
                                 <div class="box box-default permission-box collapsed-box">
                                     <div class="box-header with-border">
@@ -87,7 +96,8 @@ use Cake\Utility\Inflector;
                                     </div>
                                 </div>
                             </div>
-                            <?php endforeach; ?>
+                            <?php $count++; ?>
+                        <?php endforeach; ?>
                         </div>
                     </div>
                     <div role="tabpanel" class="tab-pane" id="groups">

--- a/src/Template/Roles/view.ctp
+++ b/src/Template/Roles/view.ctp
@@ -1,3 +1,6 @@
+<?php
+use Cake\Utility\Inflector;
+?>
 <section class="content-header">
     <div class="row">
         <div class="col-xs-12 col-md-6">
@@ -48,16 +51,8 @@
                 </ul>
                 <div class="tab-content">
                     <div role="tabpanel" class="tab-pane active" id="capabilities">
-                        <?php if (!empty($role->capabilities)) : ?>
                         <div class="row">
-                            <?php
-                            $setCapabilities = [];
-                            foreach ($role->capabilities as $cap) {
-                                $setCapabilities[] = $cap->name;
-                            }
-                            ksort($capabilities);
-                            ?>
-                            <?php foreach ($capabilities as $groupName => $groupCaps) : ?>
+                            <?php ksort($capabilities); foreach ($capabilities as $groupName => $groupCaps) : ?>
                             <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
                                 <div class="box box-default permission-box collapsed-box">
                                     <div class="box-header with-border">
@@ -68,16 +63,20 @@
                                     </div>
                                     <div class="box-body">
                                     <?php
-                                    asort($groupCaps);
-                                    foreach ($groupCaps as $k => $v) {
-                                        $checked = in_array($k, $setCapabilities);
-                                        echo $this->Form->input('capabilities[_names][' . $k . ']', [
-                                        'type' => 'checkbox',
-                                        'checked' => $checked,
-                                        'disabled' => true,
-                                        'label' => $v,
-                                        'div' => false
-                                        ]);
+                                    foreach ($groupCaps as $type => $caps) {
+                                        usort($caps, function ($a, $b) {
+                                            return strcmp($a->getDescription(), $b->getDescription());
+                                        });
+                                        echo $this->Html->tag('h4', Inflector::humanize($type) . ' ' . __('Access'));
+                                        foreach ($caps as $cap) {
+                                            echo $this->Form->input('capabilities[_names][' . $cap->getName() . ']', [
+                                                'type' => 'checkbox',
+                                                'label' => $cap->getDescription(),
+                                                'div' => false,
+                                                'disabled' => true,
+                                                'checked' => in_array($cap->getName(), $roleCaps)
+                                            ]);
+                                        }
                                     }
                                     ?>
                                     </div>
@@ -85,7 +84,6 @@
                             </div>
                             <?php endforeach; ?>
                         </div>
-                        <?php endif; ?>
                     </div>
                     <div role="tabpanel" class="tab-pane" id="groups">
                         <?php if (!empty($role->groups)) : ?>

--- a/webroot/js/permissions.js
+++ b/webroot/js/permissions.js
@@ -1,8 +1,6 @@
 (function ($) {
     // Show popup with personal permissions
     $('.delete-permission-btn').click(function () {
-        console.log('Permissions ...');
-
         return false;
     });
 })(jQuery);

--- a/webroot/js/utils.js
+++ b/webroot/js/utils.js
@@ -16,13 +16,8 @@
 
     // Find all collapsable boxes and collapse/expand them
     $('#collapse_all').click(function () {
-        var expand = $(this).is(":checked") ? true : false;
         $('.permission-box').each(function () {
-            if (expand) {
-                $(this).removeClass("collapsed-box");
-            } else {
-                $(this).addClass("collapsed-box");
-            }
+            $(this).find('[data-widget="collapse"]').trigger('click');
         });
     });
 


### PR DESCRIPTION
Adds support for defining a Table's parent modules and filtering table's results based on current user's assigned records on the parent modules.

New logic only applies to `index` and `view` actions.