### PR TITLE
Assignation field alias

### DIFF
--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -411,7 +411,7 @@ class Utils
                     $contrName,
                     static::humanizeActionName($action) . $suffix
                 );
-                $field = $table->aliasField($assignationField);
+                $field = $assignationField;
 
                 $name = static::generateCapabilityName($contrName, $action . '_' . $assignationField);
                 $options = [


### PR DESCRIPTION
Skip table alias for assignation field (`User.author`), since this is used for **filtering** find queries which might be called through an association's **target** table and the table alias (`ArticleAuthors.author`) won't match the assignation field preset table alias (`User.author`).