### PR TITLE
Bugfix on access check by type (task #5609)

### DIFF
--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -14,6 +14,7 @@ namespace RolesCapabilities\Access;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Log\Log;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
@@ -689,8 +690,18 @@ class Utils
             return false;
         }
 
-        // @todo check if method exists
         $methodName = 'hasTypeAccess' . Inflector::camelize($type);
+
+        if (! method_exists(get_called_class(), $methodName)) {
+            Log::warning(sprintf(
+                'Trying to check type access on non-existing method %s::%s',
+                get_called_class(),
+                $methodName
+            ));
+
+            return false;
+        }
+
         $result = static::$methodName($actionCapabilities[$type], $user, $url);
 
         return $result;

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -785,7 +785,7 @@ class Utils
      * @param  array  $url                Controller url
      * @return bool
      */
-    protected static function hasTypeAccessBelongsTo(array $capabilities, array $user, array $url)
+    protected static function hasTypeAccessBelongs(array $capabilities, array $user, array $url)
     {
         $entity = static::getEntityFromUrl($url);
 


### PR DESCRIPTION
* Checking if the method exists before the call, for type access check, logging non-existing methods as warnings
* Fixed method name, suffix must match `Utils::CAP_TYPE_BELONGS`