### PR TITLE
Access check 'skipTables' configuration (task #5662)

### DIFF
--- a/config/roles_capabilities.php
+++ b/config/roles_capabilities.php
@@ -5,13 +5,17 @@ return [
         'ownerCheck' => [
             // List of tables that should be skipped during record access check, to avoid infinite recursion.
             'skipTables' => [
-                'roles',
-                'capabilities',
-                'users',
-                'groups',
-                'groups_roles',
-                'groups_users',
-                'languages',
+                'byInstance' => [
+                    CakeDC\Users\Model\Table\UsersTable::class,
+                    Groups\Model\Table\GroupsTable::class,
+                    RolesCapabilities\Model\Table\CapabilitiesTable::class,
+                    RolesCapabilities\Model\Table\RolesTable::class
+                ],
+                'byTableName' => [],
+                'byRegistryAlias' => [
+                    'GroupsRoles',
+                    'GroupsUsers'
+                ]
             ],
         ],
         'accessCheck' => [

--- a/src/Event/Model/ModelBeforeFindEventsListener.php
+++ b/src/Event/Model/ModelBeforeFindEventsListener.php
@@ -67,17 +67,24 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
         // current table
         $table = $event->subject();
 
-        $skipTables = (array)Configure::read('RolesCapabilities.ownerCheck.skipTables');
-        // skip if current table is in the list of skipped tables
-        if (in_array($table->table(), $skipTables)) {
+        $config = (array)Configure::read('RolesCapabilities.ownerCheck.skipTables.byInstance');
+        if (in_array(get_class($table), $config)) {
             return;
         }
 
-        // get acl table
-        $aclTable = TableRegistry::get('RolesCapabilities.Capabilities');
+        $config = (array)Configure::read('RolesCapabilities.ownerCheck.skipTables.byRegistryAlias');
+        if (in_array($table->getRegistryAlias(), $config)) {
+            return;
+        }
+
+        $config = (array)Configure::read('RolesCapabilities.ownerCheck.skipTables.byTableName');
+        if (in_array($table->getTable(), $config)) {
+            return;
+        }
 
         // get current user
-        $user = $aclTable->getCurrentUser();
+        $user = TableRegistry::get('RolesCapabilities.Capabilities')->getCurrentUser();
+
         // skip if user not set or if is a superuser
         if (empty($user) || (!empty($user['is_superuser']) && $user['is_superuser'])) {
             return;


### PR DESCRIPTION
Extended the `skipTables` configuration support for before-find access check functionality to now include skipping tables by class instance, registry alias, and table name.