### PR TITLE
Associated records fix (task #6717)

### DIFF
--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -88,10 +88,7 @@ final class FilterQuery
             $this->filterable = false;
         }
 
-        $controller = App::className(
-            App::shortName(get_class($this->table), 'Model/Table', 'Table') . 'Controller',
-            'Controller'
-        );
+        $controller = $this->getControllerClassName();
 
         // skipping, not relevant controller found for specified table
         if (! $controller) {
@@ -111,6 +108,19 @@ final class FilterQuery
                 'action' => Utils::getCapabilities($controller, ['index'])
             ];
         }
+    }
+
+    /**
+     * Controller class name getter.
+     *
+     * @return false|string False if the class is not found or namespaced class name
+     */
+    private function getControllerClassName()
+    {
+        return App::className(
+            App::shortName(get_class($this->table), 'Model/Table', 'Table') . 'Controller',
+            'Controller'
+        );
     }
 
     /**

--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -88,15 +88,15 @@ final class FilterQuery
             $this->filterable = false;
         }
 
-        $controller = $this->getControllerClassName();
+        $controllerName = $this->getControllerClassName();
 
         // skipping, not relevant controller found for specified table
-        if (! $controller) {
+        if (! $controllerName) {
             $this->filterable = false;
         }
 
         // skipping, table's relevant controller is cake's default controller, probably a many-to-many join table
-        if ('Cake\Controller\Controller' === $controller) {
+        if ('Cake\Controller\Controller' === $controllerName) {
             $this->filterable = false;
         }
 
@@ -105,7 +105,7 @@ final class FilterQuery
                 // get current user capabilities
                 'user' => Utils::fetchUserCapabilities($this->user['id']),
                 // @todo currently we are always assume index action, this probably needs to change in the future
-                'action' => Utils::getCapabilities($controller, ['index'])
+                'action' => Utils::getCapabilities($controllerName, ['index'])
             ];
         }
     }

--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -78,13 +78,13 @@ final class FilterQuery
      * @param array $user User info
      * @return void
      */
-    public function __construct(QueryInterface $query, RepositoryInterface $table, array $user = [])
+    public function __construct(QueryInterface $query, RepositoryInterface $table, array $user)
     {
         $this->query = $query;
         $this->table = $table;
         $this->user = $user;
 
-        if (empty($this->user) || $this->isSuperuser() || $this->isSkipTable()) {
+        if (empty($this->user) || ! array_key_exists('id', $this->user) || $this->isSuperuser() || $this->isSkipTable()) {
             $this->filterable = false;
         }
 

--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -92,7 +92,14 @@ final class FilterQuery
             App::shortName(get_class($this->table), 'Model/Table', 'Table') . 'Controller',
             'Controller'
         );
+
+        // skipping, not relevant controller found for specified table
         if (! $controller) {
+            return;
+        }
+
+        // skipping, table's relevant controller is cake's default controller, probably a many-to-many join table
+        if ('Cake\Controller\Controller' === $controller) {
             return;
         }
 

--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -64,11 +64,11 @@ final class FilterQuery
     /**
      * Filterable flag
      *
-     * False by default and only set to true if specific conditions apply.
+     * True by default and only set to false if specific conditions apply.
      *
      * @var bool
      */
-    private $filterable = false;
+    private $filterable = true;
 
     /**
      * Constructor method.
@@ -85,7 +85,7 @@ final class FilterQuery
         $this->user = $user;
 
         if (empty($this->user) || $this->isSuperuser() || $this->isSkipTable()) {
-            return;
+            $this->filterable = false;
         }
 
         $controller = App::className(
@@ -95,23 +95,22 @@ final class FilterQuery
 
         // skipping, not relevant controller found for specified table
         if (! $controller) {
-            return;
+            $this->filterable = false;
         }
 
         // skipping, table's relevant controller is cake's default controller, probably a many-to-many join table
         if ('Cake\Controller\Controller' === $controller) {
-            return;
+            $this->filterable = false;
         }
 
-        $this->capabilities = [
-            // get current user capabilities
-            'user' => Utils::fetchUserCapabilities($this->user['id']),
-            // @todo currently we are always assume index action, this probably needs to change in the future
-            'action' => Utils::getCapabilities($controller, ['index'])
-        ];
-
-        // flag query as filterable
-        $this->filterable = true;
+        if ($this->filterable) {
+            $this->capabilities = [
+                // get current user capabilities
+                'user' => Utils::fetchUserCapabilities($this->user['id']),
+                // @todo currently we are always assume index action, this probably needs to change in the future
+                'action' => Utils::getCapabilities($controller, ['index'])
+            ];
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes the issue with related many-to-many records not being displayed, which was caused by the recent query filtering improvements (see https://github.com/QoboLtd/cakephp-roles-capabilities/pull/119).