### PR TITLE
User info in model layer (task #7224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 [![Latest Unstable Version](https://poser.pugx.org/qobo/cakephp-roles-capabilities/v/unstable)](https://packagist.org/packages/qobo/cakephp-roles-capabilities)
 [![License](https://poser.pugx.org/qobo/cakephp-roles-capabilities/license)](https://packagist.org/packages/qobo/cakephp-roles-capabilities)
 [![codecov](https://codecov.io/gh/QoboLtd/cakephp-roles-capabilities/branch/master/graph/badge.svg)](https://codecov.io/gh/QoboLtd/cakephp-roles-capabilities)
+[![BCH compliance](https://bettercodehub.com/edge/badge/QoboLtd/cakephp-roles-capabilitie?branch=master)](https://bettercodehub.com/)
 
 ## About
 
 CakePHP 3+ plugin managing user roles and capabilities.
 
-Developed by [Qobo](https://www.qobo.biz), used in [Qobrix](https://qobrix.com).
+This plugin is developed by [Qobo](https://www.qobo.biz) for [Qobrix](https://qobrix.com).  It can be used as standalone CakePHP plugin, or as part of the [project-template-cakephp](https://github.com/QoboLtd/project-template-cakephp) installation.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
     "require": {
-        "qobo/cakephp-utils": "^7.0",
+        "qobo/cakephp-utils": "^8.0",
         "qobo/cakephp-groups": "^9.0"
     },
     "require-dev": {

--- a/src/Access/AccessFactory.php
+++ b/src/Access/AccessFactory.php
@@ -12,7 +12,6 @@
 namespace RolesCapabilities\Access;
 
 use Cake\Core\Configure;
-use Cake\Network\Exception\ForbiddenException;
 
 /**
  *  AccessFactory Class

--- a/src/Access/CapabilitiesAccess.php
+++ b/src/Access/CapabilitiesAccess.php
@@ -11,15 +11,9 @@
  */
 namespace RolesCapabilities\Access;
 
-use Cake\Core\App;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Qobo\Utils\ModuleConfig\ConfigType;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
-use ReflectionClass;
-use ReflectionMethod;
-use RolesCapabilities\Access\Utils;
-use RolesCapabilities\Capability as Cap;
 
 /**
  *  CapabilitiesAccess class checks if user has access to specific entity

--- a/src/Access/NoAuthAccess.php
+++ b/src/Access/NoAuthAccess.php
@@ -12,7 +12,6 @@
 namespace RolesCapabilities\Access;
 
 use Cake\Core\Configure;
-use RolesCapabilities\Access\Utils;
 
 /**
  *  NoAuthAccess class

--- a/src/Access/PermissionsAccess.php
+++ b/src/Access/PermissionsAccess.php
@@ -11,7 +11,6 @@
  */
 namespace RolesCapabilities\Access;
 
-use Cake\Core\App;
 use Cake\ORM\TableRegistry;
 
 /**

--- a/src/Access/SupervisorAccess.php
+++ b/src/Access/SupervisorAccess.php
@@ -11,9 +11,6 @@
  */
 namespace RolesCapabilities\Access;
 
-use Cake\Routing\Router;
-use RolesCapabilities\Access\Utils;
-
 /**
  *  SupervisorAccess Class
  *

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -70,9 +70,18 @@ trait CapabilityTrait
      * @param  bool    $handle handle
      * @return bool
      * @throws Cake\Network\Exception\ForbiddenException
+     * @deprecated 16.3.1 use \RolesCapabilities\Access\AccessFactory::hasAccess()
      */
     protected function _checkRoleAccess($role, $handle = true)
     {
+        trigger_error(
+            sprintf(
+                '%s::_checkRoleAccess() is deprecated. Use RolesCapabilities\Access\AccessFactory::hasAccess() instead.',
+                __TRAIT__
+            ),
+            E_USER_DEPRECATED
+        );
+
         $hasAccess = false;
 
         if ($this->Capability->hasRoleAccess($role)) {

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -11,11 +11,9 @@
  */
 namespace RolesCapabilities;
 
-use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Network\Exception\ForbiddenException;
-use Cake\ORM\TableRegistry;
 use RolesCapabilities\Access\AccessFactory;
 use RolesCapabilities\Access\Utils;
 

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -15,5 +15,4 @@ use App\Controller\AppController as BaseController;
 
 class AppController extends BaseController
 {
-
 }

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -12,7 +12,6 @@
 namespace RolesCapabilities\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Core\App;
 use Cake\ORM\TableRegistry;
 use RolesCapabilities\Access\Utils;
 

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -16,6 +16,15 @@ use Cake\Core\App;
 use Cake\ORM\TableRegistry;
 use RolesCapabilities\Access\Utils;
 
+trigger_error(
+    sprintf(
+        'Use %s directly for access checks and %s for retrieving capabilities, instead of %s.',
+        'RolesCapabilities\Access\AccessFactory',
+        'RolesCapabilities\Access\Utils',
+        'RolesCapabilities\Controller\Component\CapabilityComponent'
+    ),
+    E_USER_DEPRECATED
+);
 class CapabilityComponent extends Component
 {
     /**
@@ -64,12 +73,20 @@ class CapabilityComponent extends Component
     }
 
     /**
-     * @see RolesCapabilities\Access\Utils::getAllCapabilities()
-     * @deprecated
+     * @see \RolesCapabilities\Access\Utils::getAllCapabilities()
+     * @deprecated 16.3.1 use \RolesCapabilities\Access\Utils::getAllCapabilities()
      * @return array
      */
     public function getAllCapabilities()
     {
+        trigger_error(
+            sprintf(
+                '%s() is deprecated. Use RolesCapabilities\Access\Utils::getAllCapabilities() instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return Utils::getAllCapabilities();
     }
 
@@ -79,9 +96,18 @@ class CapabilityComponent extends Component
      * @param  string $capability capability name
      * @param  string $userId     user id
      * @return bool
+     * @deprecated 16.3.1 use \RolesCapabilities\Access\AccessFactory::hasAccess()
      */
     public function hasAccess($capability, $userId = '')
     {
+        trigger_error(
+            sprintf(
+                '%s() is deprecated. Use RolesCapabilities\Access\AccessFactory::hasAccess() instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         // if not specified, get current user's id
         if (empty($userId)) {
             $userId = $this->_user['id'];
@@ -97,9 +123,18 @@ class CapabilityComponent extends Component
      * @param  string $roleId role id
      * @param  string $userId user id
      * @return bool
+     * @deprecated 16.3.1 use \RolesCapabilities\Access\AccessFactory::hasAccess()
      */
     public function hasRoleAccess($roleId, $userId = '')
     {
+        trigger_error(
+            sprintf(
+                '%s() is deprecated. Use RolesCapabilities\Access\AccessFactory::hasAccess() instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         // if not specified, get current user's id
         if (empty($userId)) {
             $userId = $this->_user['id'];

--- a/src/Controller/Component/CapabilityComponent.php
+++ b/src/Controller/Component/CapabilityComponent.php
@@ -61,7 +61,6 @@ class CapabilityComponent extends Component
         $this->_controller = $this->_registry->getController();
         $this->_user = $this->Auth->user();
         $this->_capabilitiesTable = TableRegistry::get('RolesCapabilities.Capabilities');
-        $this->_capabilitiesTable->setCurrentUser($this->Auth->user());
     }
 
     /**

--- a/src/Controller/PermissionsController.php
+++ b/src/Controller/PermissionsController.php
@@ -12,7 +12,6 @@
 namespace RolesCapabilities\Controller;
 
 use Cake\Utility\Inflector;
-use RolesCapabilities\Controller\AppController;
 
 /**
  * Permissions Controller

--- a/src/Controller/RolesController.php
+++ b/src/Controller/RolesController.php
@@ -11,6 +11,7 @@
  */
 namespace RolesCapabilities\Controller;
 
+use RolesCapabilities\Access\Utils;
 use RolesCapabilities\Controller\AppController;
 
 /**
@@ -47,7 +48,7 @@ class RolesController extends AppController
 
         $roleCaps = $this->Roles->Capabilities->find('list')->where(['role_id' => $id])->toArray();
 
-        $capabilities = $this->formatCapabilities($this->Capability->getAllCapabilities());
+        $capabilities = $this->formatCapabilities(Utils::getAllCapabilities());
 
         $this->set('capabilities', $capabilities);
         $this->set('roleCaps', $roleCaps);
@@ -83,7 +84,7 @@ class RolesController extends AppController
         }
         $groups = $this->Roles->Groups->find('list', ['limit' => 200]);
 
-        $capabilities = $this->formatCapabilities($this->Capability->getAllCapabilities());
+        $capabilities = $this->formatCapabilities(Utils::getAllCapabilities());
 
         $this->set(compact('role', 'groups', 'capabilities'));
         $this->set('_serialize', ['role']);
@@ -125,7 +126,7 @@ class RolesController extends AppController
         // fetch role capabilities
         $roleCaps = $this->Roles->Capabilities->find('list')->where(['role_id' => $id])->toArray();
 
-        $capabilities = $this->formatCapabilities($this->Capability->getAllCapabilities());
+        $capabilities = $this->formatCapabilities(Utils::getAllCapabilities());
 
         $this->set(compact('role', 'groups', 'capabilities', 'roleCaps'));
         $this->set('_serialize', ['role']);

--- a/src/Controller/RolesController.php
+++ b/src/Controller/RolesController.php
@@ -12,7 +12,6 @@
 namespace RolesCapabilities\Controller;
 
 use RolesCapabilities\Access\Utils;
-use RolesCapabilities\Controller\AppController;
 
 /**
  * Roles Controller

--- a/src/Event/Model/ModelBeforeFindEventsListener.php
+++ b/src/Event/Model/ModelBeforeFindEventsListener.php
@@ -15,7 +15,7 @@ use ArrayObject;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\ORM\Query;
-use Cake\ORM\TableRegistry;
+use Qobo\Utils\Utility\User;
 use RolesCapabilities\FilterQuery;
 
 class ModelBeforeFindEventsListener implements EventListenerInterface
@@ -66,7 +66,7 @@ class ModelBeforeFindEventsListener implements EventListenerInterface
         $filterQuery = new FilterQuery(
             $query,
             $event->getSubject(),
-            (array)TableRegistry::getTableLocator()->get('RolesCapabilities.Capabilities')->getCurrentUser()
+            User::getCurrentUser()
         );
 
         $filterQuery->execute();

--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -17,7 +17,6 @@ use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Association;
 use Cake\ORM\TableRegistry;
-use RolesCapabilities\Access\CapabilitiesAccess;
 use RolesCapabilities\Access\Utils;
 
 /**

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -11,19 +11,9 @@
  */
 namespace RolesCapabilities\Model\Table;
 
-use Cake\Core\App;
-use Cake\Core\Configure;
-use Cake\Network\Exception\ForbiddenException;
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
-use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
-use RolesCapabilities\Access\AccessFactory;
-use RolesCapabilities\Access\Utils;
-use RolesCapabilities\Capability as Cap;
-use RolesCapabilities\Model\Entity\Capability;
 
 /**
  * Capabilities Model

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -33,14 +33,6 @@ use RolesCapabilities\Model\Entity\Capability;
  */
 class CapabilitiesTable extends Table
 {
-
-    /**
-     * Current user details - used to filter list queries
-     *
-     * @var array
-     */
-    protected $_currentUser = [];
-
     /**
      * Group(s) roles
      *
@@ -100,32 +92,6 @@ class CapabilitiesTable extends Table
         $rules->add($rules->existsIn(['role_id'], 'Roles'));
 
         return $rules;
-    }
-
-    /**
-     * Current user info setter.
-     *
-     * @param  array|null $user User information
-     * @return void
-     */
-    public function setCurrentUser($user)
-    {
-        $this->_currentUser = $user;
-    }
-
-    /**
-     * Current user info getter.
-     *
-     * @param  string|null       $key Specific field to retrieve
-     * @return array|string|null
-     */
-    public function getCurrentUser($key = null)
-    {
-        if (!is_null($key)) {
-            return isset($this->_currentUser[$key]) ? $this->_currentUser[$key] : null;
-        }
-
-        return $this->_currentUser;
     }
 
     /**

--- a/src/Model/Table/CapabilitiesTable.php
+++ b/src/Model/Table/CapabilitiesTable.php
@@ -101,9 +101,18 @@ class CapabilitiesTable extends Table
      * @param  string $roleId role id
      * @param  string $userId user id
      * @return bool
+     * @deprecated 16.3.1 use \RolesCapabilities\Access\AccessFactory::hasAccess()
      */
     public function hasRoleAccess($roleId, $userId)
     {
+        trigger_error(
+            sprintf(
+                '%s::hasRoleAccess() is deprecated. Use RolesCapabilities\Access\AccessFactory::hasAccess() instead.',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
         if (is_null($roleId)) {
             return true;
         }

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -11,7 +11,6 @@
  */
 namespace RolesCapabilities\Model\Table;
 
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -11,7 +11,6 @@
  */
 namespace RolesCapabilities\Model\Table;
 
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Shell/CapabilityShell.php
+++ b/src/Shell/CapabilityShell.php
@@ -11,7 +11,6 @@
  */
 namespace RolesCapabilities\Shell;
 
-use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 
 class CapabilityShell extends Shell

--- a/src/Shell/RoleShell.php
+++ b/src/Shell/RoleShell.php
@@ -11,7 +11,6 @@
  */
 namespace RolesCapabilities\Shell;
 
-use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 
 class RoleShell extends Shell

--- a/tests/TestCase/Model/Table/CapabilitiesTableTest.php
+++ b/tests/TestCase/Model/Table/CapabilitiesTableTest.php
@@ -75,26 +75,4 @@ class CapabilitiesTableTest extends TestCase
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
-
-    public function testSetCurrentUser()
-    {
-        $data = [
-            'foo' => 'bar',
-            'blah' => true,
-        ];
-        $this->Capabilities->setCurrentUser($data);
-        $result = $this->Capabilities->getCurrentUser();
-        $this->assertEquals($data, $result, "Setting current user is broken");
-    }
-
-    public function testGetCurrentUser()
-    {
-        $data = [
-            'foo' => 'bar',
-            'blah' => true,
-        ];
-        $this->Capabilities->setCurrentUser($data);
-        $result = $this->Capabilities->getCurrentUser('foo');
-        $this->assertEquals('bar', $result, "Getting keys of current user is broken");
-    }
 }


### PR DESCRIPTION
Adjusted code that handles passing user information to model layer, this functionality is now handled by [Qobo/Utils](https://github.com/QoboLtd/cakephp-utils) User utility class (this PR requires merging and releasing of [this](https://github.com/QoboLtd/cakephp-utils/pull/137) work).

This is a feature branch which includes work done in PRs https://github.com/QoboLtd/cakephp-roles-capabilities/pull/122 and https://github.com/QoboLtd/cakephp-roles-capabilities/pull/123