### PR TITLE
Fixes issue with incompatible table - id being provided (task #8244)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     "autoload-dev": {
         "psr-4": {
             "RolesCapabilities\\Test\\": "tests/",
+            "Groups\\Test\\": "vendor/qobo/cakephp-groups/tests/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
     },

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -14,6 +14,7 @@ namespace RolesCapabilities\Access;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Log\Log;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -801,6 +802,8 @@ class Utils
                 $table = TableRegistry::get($tableName);
                 $entity = $table->get($id);
             } catch (InvalidPrimaryKeyException $e) {
+                Log::warning("Failed to fetch record with id [$id] from table [$tableName]");
+            } catch (RecordNotFoundException $e) {
                 Log::warning("Failed to fetch record with id [$id] from table [$tableName]");
             }
         }

--- a/tests/TestCase/Access/UtilsTest.php
+++ b/tests/TestCase/Access/UtilsTest.php
@@ -11,7 +11,8 @@ class UtilsTest extends TestCase
 {
     public $fixtures = [
         'plugin.roles_capabilities.users',
-        'plugin.roles_capabilities.groups'
+        'plugin.roles_capabilities.groups',
+        'plugin.groups.groups_users'
     ];
 
     public function testGetControllerFullName(): void

--- a/tests/TestCase/Access/UtilsTest.php
+++ b/tests/TestCase/Access/UtilsTest.php
@@ -317,21 +317,6 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * Test getEntityFromUrl method with the plugin set
-     */
-    public function testGetEntityFromUrlWithWrongId()
-    {
-        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
-        $url = [
-            '0' => "00900000-0090-0000-0000-000090000001",
-            'plugin' => null,
-            'controller' => 'Users'
-        ];
-
-        $data = Utility::callStaticPrivateMethod('\RolesCapabilities\Access\Utils', 'getEntityFromUrl', [$url]);
-    }
-
-    /**
      * Test hasAccessInCapabilities method the user has the capabilities
      */
     public function testHasAccessInCapabilities()


### PR DESCRIPTION
In cases where the table is not compatible with the ID (articles table, id from authors) we catch the exception and return a null value. The bug was introduced after phpstan fixes, because we used to catch the all exceptions but now we switched to more specific.