### PR TITLE
Extend parent permissions (task #10835)

### DIFF
--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -54,13 +54,6 @@ final class FilterQuery
     private $user;
 
     /**
-     * Association types supported for parent join functionality.
-     *
-     * @var array
-     */
-    private $parentJoinAssocations = ['manyToMany', 'manyToOne'];
-
-    /**
      * Filterable flag
      *
      * True by default and only set to false if specific conditions apply.
@@ -214,7 +207,7 @@ final class FilterQuery
      *
      * @return \Cake\Datasource\QueryInterface
      */
-    public function execute(): \Cake\Datasource\QueryInterface
+    public function execute(): QueryInterface
     {
         // query is not filterable, return it as is.
         if (! $this->filterable) {
@@ -400,6 +393,10 @@ final class FilterQuery
 
         $result = [];
         foreach ($this->table->associations() as $association) {
+            if (! $this->isSupportedJoinAssociation($association)) {
+                continue;
+            }
+
             $conditions = $this->getParentJoin($association, $modules);
             if (empty($conditions)) {
                 continue;
@@ -460,6 +457,17 @@ final class FilterQuery
         }
 
         return $result;
+    }
+
+    /**
+     * Supported JOIN assocation validator.
+     *
+     * @param \Cake\ORM\Association $association Association instance
+     * @return bool
+     */
+    private function isSupportedJoinAssociation(Association $association) : bool
+    {
+        return in_array($association->type(), [Association::MANY_TO_MANY, Association::MANY_TO_ONE]);
     }
 
     /**

--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -248,7 +248,12 @@ final class FilterQuery
         return $result;
     }
 
-    private function getParentPermissions()
+    /**
+     * User permissions getter, by parent module.
+     *
+     * @return mixed[]
+     */
+    private function getParentPermissions() : array
     {
         $result = [];
         foreach ($this->table->associations() as $association) {

--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -471,6 +471,28 @@ final class FilterQuery
     }
 
     /**
+     * Parent module assocation validator.
+     *
+     * @param \Cake\ORM\Association $association Association instance
+     * @return bool
+     */
+    private function isParentModuleAssociation(Association $association) : bool
+    {
+        return in_array($this->getModelByAssociation($association), $this->getParentModules());
+    }
+
+    /**
+     * Model name getter, by association.
+     *
+     * @param \Cake\ORM\Association $association Association instance
+     * @return string
+     */
+    private function getModelByAssociation(Association $association) : string
+    {
+        return App::shortName(get_class($association->getTarget()), 'Model/Table', 'Table');
+    }
+
+    /**
      * Return belong to statement.
      *
      * @return mixed[]


### PR DESCRIPTION
This PR extends query filtering functionality, by filtering records based on parent module permissions. For example, you can fetch articles of an author if you have _view_ permission access to that author.

This will require to set the _permissions_parent_modules_ for articles configuration parameter as following:
```json
# Articles/config.json
{
    "table": {
        "permissions_parent_modules": ["Authors"]
    }
}
```

Additionally through a role's capabilities, you will need to assign the capability _"Allow fetch if owner on parent module (Authors)"_, under the _Parent Access_ tab.