### PR TITLE
Bugfix on Filter Query (task #10835)

### DIFF
--- a/src/FilterQuery.php
+++ b/src/FilterQuery.php
@@ -272,8 +272,13 @@ final class FilterQuery
             $foreignKey = $association->getForeignKey();
             Assert::string($foreignKey);
 
+            $values = $this->getPermissionsByModel($this->getModelByAssociation($association));
+            if (empty($values)) {
+                continue;
+            }
+
             $field = sprintf('%s IN', $foreignKey);
-            $result[$field] = $this->getPermissionsByModel($this->getModelByAssociation($association));
+            $result[$field] = $values;
         }
 
         return $result;


### PR DESCRIPTION
Add _where_ clause conditions only if parent permissions are found, fixes the following database error:
```
Cake \ Database \ Exception (500)
Impossible to generate condition with empty list of values for field (`author_id`)
```