### PR TITLE
Role import improvement (task #11200)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "qobo/cakephp-utils": "^12.0",
+        "qobo/cakephp-utils": "^13.0",
         "qobo/cakephp-groups": "^11.0"
     },
     "require-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,8 @@ parameters:
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort
+    ignoreErrors:
+        - '#Call to function is_callable\(\) with array\(string, .*\) will always evaluate to false.#'
 includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -52,34 +52,35 @@ class ImportTask extends Shell
                 continue;
             }
 
-            if ($table->exists(['name' => $role['name']])) {
-                $this->warn("Role [" . $role['name'] . "] already exists. Skipping.");
+            $entity = $table->find()->where(['name' => $role['name']])->first();
+            Assert::nullOrIsInstanceOf($entity, EntityInterface::class);
+
+            if (null !== $entity && $entity->get('deny_edit')) {
+                $this->warn(sprintf('Roles "%s" already exists and is not allowed to be modified.', $role['name']));
                 continue;
             }
 
-            $this->info("Role [" . $role['name'] . "] does not exist. Creating.");
-            $entity = $table->newEntity();
+            null === $entity ?
+                $this->info(sprintf('Creating role "%s".', $role['name'])) :
+                $this->info(sprintf('Updating role "%s".', $role['name']));
+
+            $entity = null === $entity ? $table->newEntity() : $entity;
             $entity = $table->patchEntity($entity, $role);
 
-            $group = $this->getGroupByRoleName($entity->get('name'));
-            if (empty($group)) {
-                $this->abort("Failed to fetch group [" . $entity->get('name') . "]");
-            }
-
-            $result = $table->save($entity);
-            if (!$result) {
+            if (! $table->save($entity)) {
                 $this->err("Errors: \n" . implode("\n", $this->getImportErrors($entity)));
                 $this->abort("Failed to create role [" . $entity->get('name') . "]");
             }
 
-            $msg = 'Role [' . $entity->get('name') . '] imported';
+            $group = $this->getGroupByRoleName($entity->get('name'));
+            if (null === $group) {
+                continue;
+            }
+
             // associate imported role with matching group
             if ($table->Groups->link($entity, [$group])) {
-                $msg .= ' and associated with group [' . $group->get('name') . ']';
+                $this->info(sprintf('Role "%s" linked with group "%s"', $entity->get('name'), $group->get('name')));
             }
-            $msg .= ' successfully';
-
-            $this->info($msg);
         }
 
         $this->success('System roles imported successfully');

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -52,9 +52,13 @@ class ImportTask extends Shell
                 continue;
             }
 
-            $entity = $table->find()->where(['name' => $role['name']])->contain(['Groups' => function ($q) {
+            $query = $table->find()->where(['name' => $role['name']])->contain(['Groups' => function ($q) {
                 return $q->select(['Groups.id']);
-            }])->first();
+            }]);
+
+            Assert::isInstanceOf($query, \Cake\ORM\Query::class);
+
+            $entity = $query->first();
 
             Assert::nullOrIsInstanceOf($entity, EntityInterface::class);
 

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -56,11 +56,11 @@ class ImportTask extends Shell
                 return $q->select(['Groups.id']);
             }])->first();
 
-            $linkedGroups = array_map(function ($item) {
+            Assert::nullOrIsInstanceOf($entity, EntityInterface::class);
+
+            $linkedGroups = null === $entity ? [] : array_map(function ($item) {
                 return $item->get('id');
             }, $entity->get('groups'));
-
-            Assert::nullOrIsInstanceOf($entity, EntityInterface::class);
 
             if (null !== $entity && $entity->get('deny_edit')) {
                 $this->warn(sprintf('Roles "%s" already exists and is not allowed to be modified.', $role['name']));

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -6,9 +6,6 @@ use Cake\TestSuite\TestCase;
 use RolesCapabilities\Shell\Task\ImportTask;
 use Webmozart\Assert\Assert;
 
-/**
- * @property \RolesCapabilities\Model\Table\RolesTable $Roles
- */
 class ImportTaskTest extends TestCase
 {
     public $fixtures = [

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -1,0 +1,91 @@
+<?php
+namespace RolesCapabilities\Test\TestCase\Shell\Task;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use RolesCapabilities\Shell\Task\ImportTask;
+use Webmozart\Assert\Assert;
+
+/**
+ * @property \RolesCapabilities\Model\Table\RolesTable $Roles
+ */
+class ImportTaskTest extends TestCase
+{
+    public $fixtures = [
+        'plugin.Groups.groups',
+        'plugin.RolesCapabilities.groups_roles',
+        'plugin.RolesCapabilities.roles'
+    ];
+
+    private $task;
+    private $table;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->table = TableRegistry::getTableLocator()->get('RolesCapabilities.Roles');
+
+        /** @var \Cake\Console\ConsoleIo */
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+
+        $this->task = new ImportTask($io);
+    }
+
+    public function tearDown()
+    {
+        unset($this->table);
+        unset($this->task);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider rolesProvider
+     * @param mixed[] $data Role data
+     */
+    public function testMain(array $data): void
+    {
+        $this->table->deleteAll([]);
+
+        $this->task->main();
+
+        $query = $this->table->find()->where(['name' => $data['name']]);
+        $this->assertSame(1, $query->count());
+
+        $entity = $query->firstOrFail();
+        Assert::isInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
+        $role = $entity->toArray();
+
+        $this->assertSame([], array_diff_assoc($data, $role));
+        $initialModifiedDate = $role['modified'];
+
+        $this->table->updateAll(['description' => 'Some random description ' . uniqid()], []);
+
+        // sleeping so we can capture the modified time diff.
+        sleep(1);
+
+        $this->task->main();
+
+        $entity = $this->table->find()->where(['name' => $data['name']])->firstOrFail();
+        Assert::isInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
+        $updated = $entity->toArray();
+
+        $data['deny_edit'] ?
+            $this->assertTrue($updated['modified']->getTimestamp() === $initialModifiedDate->getTimestamp()) :
+            $this->assertTrue($updated['modified']->getTimestamp() > $initialModifiedDate->getTimestamp());
+
+        $this->assertSame([], array_diff_assoc($data, $updated));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function rolesProvider() : array
+    {
+        return [
+            [['name' => 'Admins', 'deny_edit' => true, 'deny_delete' => true]],
+            [['name' => 'Everyone', 'deny_edit' => false, 'deny_delete' => true]]
+        ];
+    }
+}


### PR DESCRIPTION
This PR improves on import shell task, to allow updating existing system roles. Roles which are flagged with `deny_edit`, will still be skipped.