### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,19 +21,9 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-utils.git"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-groups.git"
-        }
-    ],
     "require": {
-        "qobo/cakephp-utils": "dev-cakephp-v38a",
-        "qobo/cakephp-groups": "dev-cakephp-v38"
+        "qobo/cakephp-utils": "^13.0",
+        "qobo/cakephp-groups": "^11.0"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,16 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
+            "url": "https://github.com/QoboLtd/cakephp-utils.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/QoboLtd/cakephp-groups.git"
         }
     ],
     "require": {
-        "qobo/cakephp-utils": "^13.0",
-        "qobo/cakephp-groups": "^11.0"
+        "qobo/cakephp-utils": "dev-cakephp-v38a",
+        "qobo/cakephp-groups": "dev-cakephp-v38"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"
@@ -61,6 +65,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/config/Migrations/20180516115848_RenameRolesTable.php
+++ b/config/Migrations/20180516115848_RenameRolesTable.php
@@ -13,6 +13,7 @@ class RenameRolesTable extends AbstractMigration
     public function change()
     {
         $this->table('roles')
-            ->rename('qobo_roles');
+            ->rename('qobo_roles')
+            ->update();
     }
 }

--- a/config/Migrations/20180516120408_RenamePermissionsTable.php
+++ b/config/Migrations/20180516120408_RenamePermissionsTable.php
@@ -13,6 +13,7 @@ class RenamePermissionsTable extends AbstractMigration
     public function change()
     {
         $this->table('permissions')
-            ->rename('qobo_permissions');
+            ->rename('qobo_permissions')
+            ->update();
     }
 }

--- a/config/Migrations/20180516120717_RenameCapabilitiesTable.php
+++ b/config/Migrations/20180516120717_RenameCapabilitiesTable.php
@@ -13,6 +13,7 @@ class RenameCapabilitiesTable extends AbstractMigration
     public function change()
     {
         $this->table('capabilities')
-            ->rename('qobo_capabilities');
+            ->rename('qobo_capabilities')
+            ->update();
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/src/Access/AccessFactory.php
+++ b/src/Access/AccessFactory.php
@@ -12,7 +12,6 @@
 namespace RolesCapabilities\Access;
 
 use Cake\Core\Configure;
-use RolesCapabilities\Access\AccessInterface;
 
 /**
  *  AccessFactory Class

--- a/src/Access/Utils.php
+++ b/src/Access/Utils.php
@@ -852,7 +852,7 @@ class Utils
 
         foreach ($table->associations() as $association) {
             // skip non-assignation models
-            if (!in_array($association->className(), $assignationModels)) {
+            if (!in_array($association->getClassName(), $assignationModels)) {
                 continue;
             }
 

--- a/src/CapabilityTrait.php
+++ b/src/CapabilityTrait.php
@@ -12,8 +12,6 @@
 namespace RolesCapabilities;
 
 use Cake\Core\Configure;
-use Cake\Event\Event;
-use Cake\Http\Exception\ForbiddenException;
 use RolesCapabilities\Access\AccessFactory;
 use RolesCapabilities\Access\Utils;
 

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -14,7 +14,6 @@ namespace RolesCapabilities\Model\Table;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
-use RolesCapabilities\Model\Entity\Role;
 
 /**
  * Roles Model

--- a/tests/TestCase/Access/CapabilitiesAccessTest.php
+++ b/tests/TestCase/Access/CapabilitiesAccessTest.php
@@ -12,9 +12,9 @@ use RolesCapabilities\Capability;
 class CapabilitiesAccessTest extends TestCase
 {
     public $fixtures = [
-        'plugin.roles_capabilities.users',
-        'plugin.roles_capabilities.groups',
-        'plugin.roles_capabilities.groups_users',
+        'plugin.RolesCapabilities.Users',
+        'plugin.RolesCapabilities.Groups',
+        'plugin.RolesCapabilities.GroupsUsers',
     ];
 
     public function setUp()

--- a/tests/TestCase/Access/UtilsTest.php
+++ b/tests/TestCase/Access/UtilsTest.php
@@ -10,9 +10,9 @@ use RolesCapabilities\Access\Utils;
 class UtilsTest extends TestCase
 {
     public $fixtures = [
-        'plugin.roles_capabilities.users',
-        'plugin.roles_capabilities.groups',
-        'plugin.groups.groups_users',
+        'plugin.RolesCapabilities.Users',
+        'plugin.RolesCapabilities.Groups',
+        'plugin.Groups.GroupsUsers',
     ];
 
     public function testGetControllerFullName(): void

--- a/tests/TestCase/Controller/CapabilitiesControllerTest.php
+++ b/tests/TestCase/Controller/CapabilitiesControllerTest.php
@@ -16,7 +16,7 @@ class CapabilitiesControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.roles_capabilities.capabilities',
+        'plugin.RolesCapabilities.Capabilities',
     ];
 
     /**

--- a/tests/TestCase/Controller/PermissionsControllerTest.php
+++ b/tests/TestCase/Controller/PermissionsControllerTest.php
@@ -16,8 +16,8 @@ class PermissionsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.roles_capabilities.permissions',
-        'plugin.roles_capabilities.users',
+        'plugin.RolesCapabilities.Permissions',
+        'plugin.RolesCapabilities.Users',
     ];
 
     /**

--- a/tests/TestCase/Controller/RolesControllerTest.php
+++ b/tests/TestCase/Controller/RolesControllerTest.php
@@ -16,7 +16,7 @@ class RolesControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.roles_capabilities.roles',
+        'plugin.RolesCapabilities.Roles',
     ];
 
     /**

--- a/tests/TestCase/FilterQueryTest.php
+++ b/tests/TestCase/FilterQueryTest.php
@@ -21,11 +21,11 @@ class FilterQueryTest extends TestCase
      * @var array Fixtures list
      */
     public $fixtures = [
-        'plugin.roles_capabilities.users',
-        'plugin.roles_capabilities.groups_roles',
-        'plugin.roles_capabilities.groups_users',
-        'plugin.roles_capabilities.roles',
-        'plugin.roles_capabilities.capabilities',
+        'plugin.RolesCapabilities.Users',
+        'plugin.RolesCapabilities.GroupsRoles',
+        'plugin.RolesCapabilities.GroupsUsers',
+        'plugin.RolesCapabilities.Roles',
+        'plugin.RolesCapabilities.Capabilities',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/CapabilitiesTableTest.php
+++ b/tests/TestCase/Model/Table/CapabilitiesTableTest.php
@@ -20,8 +20,8 @@ class CapabilitiesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.roles_capabilities.capabilities',
-        'plugin.roles_capabilities.roles',
+        'plugin.RolesCapabilities.Capabilities',
+        'plugin.RolesCapabilities.Roles',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/PermissionsTableTest.php
+++ b/tests/TestCase/Model/Table/PermissionsTableTest.php
@@ -25,8 +25,8 @@ class PermissionsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.roles_capabilities.permissions',
-        'plugin.roles_capabilities.users',
+        'plugin.RolesCapabilities.Permissions',
+        'plugin.RolesCapabilities.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/tests/TestCase/Model/Table/RolesTableTest.php
@@ -20,8 +20,8 @@ class RolesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.roles_capabilities.roles',
-        'plugin.roles_capabilities.capabilities',
+        'plugin.RolesCapabilities.Roles',
+        'plugin.RolesCapabilities.Capabilities',
     ];
 
     /**

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -10,9 +10,9 @@ use Webmozart\Assert\Assert;
 class ImportTaskTest extends TestCase
 {
     public $fixtures = [
-        'plugin.Groups.groups',
-        'plugin.RolesCapabilities.groups_roles',
-        'plugin.RolesCapabilities.roles',
+        'plugin.Groups.Groups',
+        'plugin.RolesCapabilities.GroupsRoles',
+        'plugin.RolesCapabilities.Roles',
     ];
 
     private $task;


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

